### PR TITLE
Add support for new panel types and options

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,0 +1,8 @@
+Build and run
+-------------
+
+Build: `python setup.py bdist_wheel`
+
+This will create a package in dist folder which can be installed using the following command:
+`pip install dist/grafyaml-0.0.9.dev15-py2.py3-none-any.whl`
+

--- a/grafana_dashboards/schema/annotations.py
+++ b/grafana_dashboards/schema/annotations.py
@@ -1,0 +1,34 @@
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import voluptuous as v
+
+
+class Annotations(object):
+
+    def get_schema(self):
+        list = {
+            v.Required('datasource'): v.All(str),
+            v.Required('enable'): v.All(bool),
+            v.Required('expr'): v.All(str),
+            v.Required('hide'): v.All(bool),
+            v.Required('name'): v.All(str),
+            v.Optional('limit'): int,
+            v.Optional('titleFormat'): v.All(str),
+        }
+
+        schema = v.Schema({
+            v.Optional('annotations'): {"list": [list]},
+        })
+        return schema

--- a/grafana_dashboards/schema/annotations.py
+++ b/grafana_dashboards/schema/annotations.py
@@ -26,6 +26,9 @@ class Annotations(object):
             v.Required('name'): v.All(str),
             v.Optional('limit'): int,
             v.Optional('titleFormat'): v.All(str),
+            v.Optional('tagKeys'): v.All(str),
+            v.Optional('textFormat'): v.All(str),
+            v.Optional('type'): v.All(str),
         }
 
         schema = v.Schema({

--- a/grafana_dashboards/schema/annotations.py
+++ b/grafana_dashboards/schema/annotations.py
@@ -29,6 +29,7 @@ class Annotations(object):
             v.Optional('tagKeys'): v.All(str),
             v.Optional('textFormat'): v.All(str),
             v.Optional('type'): v.All(str),
+            v.Optional('iconColor'): v.All(str),
         }
 
         schema = v.Schema({

--- a/grafana_dashboards/schema/dashboard.py
+++ b/grafana_dashboards/schema/dashboard.py
@@ -28,6 +28,7 @@ class Dashboard(object):
             v.Required('timezone', default='utc'): v.Any('browser', 'utc'),
             v.Required('title'): v.All(str, v.Length(min=1)),
             v.Optional('id'): int,
+            v.Optional('editable'): bool,
             v.Optional('tags'): [v.Any(str, v.Length(min=1))],
             v.Optional('time'): {
                 v.Required('from'): v.Any(v.Datetime(), str),

--- a/grafana_dashboards/schema/dashboard.py
+++ b/grafana_dashboards/schema/dashboard.py
@@ -15,6 +15,7 @@
 import voluptuous as v
 
 from grafana_dashboards.schema.links import Links
+from grafana_dashboards.schema.annotations import Annotations
 from grafana_dashboards.schema.row import Row
 from grafana_dashboards.schema.template import Template
 
@@ -39,5 +40,7 @@ class Dashboard(object):
         dashboard.update(rows.schema)
         templating = Template().get_schema()
         dashboard.update(templating.schema)
+        annotations = Annotations().get_schema()
+        dashboard.update(annotations.schema)
 
         return dashboard

--- a/grafana_dashboards/schema/panel/__init__.py
+++ b/grafana_dashboards/schema/panel/__init__.py
@@ -22,6 +22,7 @@ from grafana_dashboards.schema.panel.row import Row
 from grafana_dashboards.schema.panel.singlestat import Singlestat
 from grafana_dashboards.schema.panel.stat import Stat
 from grafana_dashboards.schema.panel.text import Text
+from grafana_dashboards.schema.panel.table import Table
 
 
 class Panel(object):
@@ -51,6 +52,8 @@ class Panel(object):
                     schema = Text().get_schema()
                 elif panel['type'] == 'row':
                     schema = Row().get_schema()
+                elif panel['type'] == 'table-old':
+                    schema = Table().get_schema()
 
                 res.append(schema(panel))
 

--- a/grafana_dashboards/schema/panel/__init__.py
+++ b/grafana_dashboards/schema/panel/__init__.py
@@ -20,6 +20,7 @@ from grafana_dashboards.schema.panel.graph import Graph
 from grafana_dashboards.schema.panel.logs import Logs
 from grafana_dashboards.schema.panel.row import Row
 from grafana_dashboards.schema.panel.singlestat import Singlestat
+from grafana_dashboards.schema.panel.stat import Stat
 from grafana_dashboards.schema.panel.text import Text
 
 
@@ -44,6 +45,8 @@ class Panel(object):
                     schema = Logs().get_schema()
                 elif panel['type'] == 'singlestat':
                     schema = Singlestat().get_schema()
+                elif panel['type'] == 'stat':
+                    schema = Stat().get_schema()
                 elif panel['type'] == 'text':
                     schema = Text().get_schema()
                 elif panel['type'] == 'row':

--- a/grafana_dashboards/schema/panel/__init__.py
+++ b/grafana_dashboards/schema/panel/__init__.py
@@ -17,6 +17,7 @@ import voluptuous as v
 from grafana_dashboards.schema.panel.base import Base
 from grafana_dashboards.schema.panel.dashlist import Dashlist
 from grafana_dashboards.schema.panel.graph import Graph
+from grafana_dashboards.schema.panel.logs import Logs
 from grafana_dashboards.schema.panel.row import Row
 from grafana_dashboards.schema.panel.singlestat import Singlestat
 from grafana_dashboards.schema.panel.text import Text
@@ -39,6 +40,8 @@ class Panel(object):
                     schema = Dashlist().get_schema()
                 elif panel['type'] == 'graph':
                     schema = Graph().get_schema()
+                elif panel['type'] == 'logs':
+                    schema = Logs().get_schema()
                 elif panel['type'] == 'singlestat':
                     schema = Singlestat().get_schema()
                 elif panel['type'] == 'text':

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -46,6 +46,7 @@ class Base(object):
             v.Optional('id'): int,
             v.Optional('format'): v.Any(self.formats, v.Length(min=1)),
             v.Optional('transparent'): v.All(bool),
+            v.Optional('height'): v.All(int),
         }
 
     def get_schema(self):

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -32,7 +32,7 @@ class Base(object):
                     u'm3', u'watt', u'kwatt', u'watth', u'kwatth', u'joule',
                     u'ev', u'amp', u'volt', u'celsius', u'farenheit',
                     u'kelvin', u'pressurembar', u'pressurehpa', u'pressurehg',
-                    u'pressurepsi', u'reqps')
+                    u'pressurepsi', u'reqps', u'dtdurations')
 
     def __init__(self):
         self.base = {

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -41,7 +41,7 @@ class Base(object):
             v.Required('span', default=12): v.All(int, v.Range(min=0, max=12)),
             v.Required('title'): v.All(str, v.Length(min=1)),
             v.Required('type'): v.Any(
-                'dashlist', 'graph', 'singlestat', 'text', 'row'),
+                'dashlist', 'graph', 'logs', 'singlestat', 'text', 'row'),
             v.Optional('id'): int,
             v.Optional('format'): v.Any(self.formats, v.Length(min=1)),
             v.Optional('transparent'): v.All(bool),

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -32,7 +32,7 @@ class Base(object):
                     u'm3', u'watt', u'kwatt', u'watth', u'kwatth', u'joule',
                     u'ev', u'amp', u'volt', u'celsius', u'farenheit',
                     u'kelvin', u'pressurembar', u'pressurehpa', u'pressurehg',
-                    u'pressurepsi')
+                    u'pressurepsi', u'reqps')
 
     def __init__(self):
         self.base = {

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -42,7 +42,7 @@ class Base(object):
             v.Required('title'): v.All(str, v.Length(min=1)),
             v.Required('type'): v.Any(
                 'dashlist', 'graph', 'logs', 'singlestat', 'text', 'row',
-                'stat'),
+                'stat', 'table-old'),
             v.Optional('id'): int,
             v.Optional('format'): v.Any(self.formats, v.Length(min=1)),
             v.Optional('transparent'): v.All(bool),

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -41,7 +41,8 @@ class Base(object):
             v.Required('span', default=12): v.All(int, v.Range(min=0, max=12)),
             v.Required('title'): v.All(str, v.Length(min=1)),
             v.Required('type'): v.Any(
-                'dashlist', 'graph', 'logs', 'singlestat', 'text', 'row'),
+                'dashlist', 'graph', 'logs', 'singlestat', 'text', 'row',
+                'stat'),
             v.Optional('id'): int,
             v.Optional('format'): v.Any(self.formats, v.Length(min=1)),
             v.Optional('transparent'): v.All(bool),

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -47,6 +47,7 @@ class Base(object):
             v.Optional('format'): v.Any(self.formats, v.Length(min=1)),
             v.Optional('transparent'): v.All(bool),
             v.Optional('height'): v.All(int),
+            v.Optional('description'): v.All(str),
         }
 
     def get_schema(self):

--- a/grafana_dashboards/schema/panel/graph.py
+++ b/grafana_dashboards/schema/panel/graph.py
@@ -58,6 +58,7 @@ class Graph(Base):
             v.Optional('total', default=False): v.All(bool),
             v.Optional('values', default=False): v.All(bool),
             v.Optional('sortDesc', default=False): v.All(bool),
+            v.Optional('sort'): v.All(str),
         }
 
         null_point_modes = v.Any('connected', 'null', 'null as zero')

--- a/grafana_dashboards/schema/panel/graph.py
+++ b/grafana_dashboards/schema/panel/graph.py
@@ -108,7 +108,7 @@ class Graph(Base):
             v.Optional('leftYAxisLabel'): v.All(str, v.Length(min=1)),
             v.Optional('legend'): v.All(legend),
             v.Required('lines', default=True): v.All(bool),
-            v.Required('linewidth', default=2): v.All(int),
+            v.Required('linewidth', default=1): v.All(int),
             v.Optional('minSpan'): v.All(int, v.Range(min=0, max=12)),
             v.Optional('nullPointMode'): v.All(null_point_modes),
             v.Required('percentage', default=False): v.All(bool),

--- a/grafana_dashboards/schema/panel/graph.py
+++ b/grafana_dashboards/schema/panel/graph.py
@@ -85,10 +85,16 @@ class Graph(Base):
             v.Optional('pointsradius'): v.All(int, v.Range(min=1, max=5)),
             v.Optional('stack'): v.All(v.Any(bool, 'A', 'B', 'C', 'D')),
             v.Optional('color'): v.All(str),
+            v.Optional('aliasColors', default={}): v.All(dict),
             v.Optional('yaxis'): v.All(int, v.Range(min=1, max=2)),
             v.Optional('zindex'): v.All(int, v.Range(min=-3, max=3)),
-            v.Optional('transform'): v.All(v.Any('negative-Y')),
+            v.Optional('transform'): v.All(str),
             v.Optional('legend'): v.All(bool),
+            v.Optional('hideTooltip'): v.All(bool),
+            v.Optional('lineWidth'): v.All(int),
+            v.Optional('dashLength'): v.All(int),
+            v.Optional('spaceLength'): v.All(int),
+            v.Optional('pointradius'): v.All(int),
         }
         series_overrides = [series_override]
 
@@ -107,6 +113,7 @@ class Graph(Base):
             v.Optional('nullPointMode'): v.All(null_point_modes),
             v.Required('percentage', default=False): v.All(bool),
             v.Required('pointradius', default=5): v.All(int),
+            v.Optional('dashLength'): v.All(int),
             v.Required('points', default=False): v.All(bool),
             v.Optional('repeat'): v.All(str),
             v.Optional('rightYAxisLabel'): v.All(str, v.Length(min=1)),
@@ -115,6 +122,7 @@ class Graph(Base):
             v.Required('stack', default=False): v.All(bool),
             v.Required('steppedLine', default=False): v.All(bool),
             v.Required('targets', default=[]): v.All(list),
+            v.Required('thresholds', default=[]): v.All(list),
             v.Optional('timeFrom'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
             v.Optional('timeShift'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
             v.Optional('tooltip'): v.All(tooltip),
@@ -125,4 +133,4 @@ class Graph(Base):
             v.Optional('yaxes'): v.All(yaxes_format, v.Length(min=2, max=2)),
         }
         graph.update(self.base)
-        return v.Schema(graph)
+        return v.Schema(graph, extra=True)

--- a/grafana_dashboards/schema/panel/graph.py
+++ b/grafana_dashboards/schema/panel/graph.py
@@ -57,6 +57,7 @@ class Graph(Base):
             v.Optional('show', default=False): v.All(bool),
             v.Optional('total', default=False): v.All(bool),
             v.Optional('values', default=False): v.All(bool),
+            v.Optional('sortDesc', default=False): v.All(bool),
         }
 
         null_point_modes = v.Any('connected', 'null', 'null as zero')

--- a/grafana_dashboards/schema/panel/graph.py
+++ b/grafana_dashboards/schema/panel/graph.py
@@ -74,6 +74,7 @@ class Graph(Base):
         series_override = {
             v.Required('alias'): v.All(str, v.Length(min=1)),
             v.Optional('bars'): v.All(bool),
+            v.Optional('dashes'): v.All(bool),
             v.Optional('lines'): v.All(bool),
             v.Optional('fill'): v.All(int, v.Range(min=0, max=10)),
             v.Optional('width'): v.All(int, v.Range(min=1, max=10)),

--- a/grafana_dashboards/schema/panel/logs.py
+++ b/grafana_dashboards/schema/panel/logs.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import voluptuous as v
+
+from grafana_dashboards.schema.panel.base import Base
+
+
+class Logs(Base):
+
+    def get_schema(self):
+
+        alert_format = {
+            # could enforce "evaulator"/"operator"/"query" on this...
+            v.Required('conditions'): v.All(list),
+            v.Required('frequency', default='60s'): v.All(str),
+            v.Required('name'): v.All(str),
+            v.Required('executionErrorState', default='alerting'): (
+                v.Any('alerting', 'keep_state')),
+            v.Required('noDataState', default='no_data'): (
+                v.Any('no_data', 'alerting', 'ok', 'keep_state')),
+            v.Optional('notifications', default=[]): v.All(list),
+        }
+
+        yaxes_format = [
+            {
+                v.Optional('decimals'): v.All(int),
+                v.Optional('format', default='short'): Base.formats,
+                v.Optional('label', default=''): v.All(str),
+                v.Optional('logBase', default=1): v.All(int, v.Range(min=1)),
+                v.Optional('max'): v.All(int),
+                v.Optional('min'): v.All(int),
+                v.Optional('show', default=True): v.All(bool),
+            }
+        ]
+
+        legend = {
+            v.Optional('alignAsTable', default=False): v.All(bool),
+            v.Optional('avg', default=False): v.All(bool),
+            v.Optional('current', default=False): v.All(bool),
+            v.Optional('max', default=False): v.All(bool),
+            v.Optional('min', default=False): v.All(bool),
+            v.Optional('rightSide', default=False): v.All(bool),
+            v.Optional('show', default=False): v.All(bool),
+            v.Optional('total', default=False): v.All(bool),
+            v.Optional('values', default=False): v.All(bool),
+        }
+
+        null_point_modes = v.Any('connected', 'null', 'null as zero')
+        value_types = v.Any('individual', 'cumulative')
+
+        tooltip = {
+            v.Required('query_as_alias', default=True): v.All(bool),
+            v.Required('shared', default=True): v.All(bool),
+            v.Required('value_type', default='cumulative'): v.All(value_types),
+            v.Optional('sort'): v.Range(min=0, max=2),
+        }
+
+        series_override = {
+            v.Required('alias'): v.All(str, v.Length(min=1)),
+            v.Optional('bars'): v.All(bool),
+            v.Optional('lines'): v.All(bool),
+            v.Optional('fill'): v.All(int, v.Range(min=0, max=10)),
+            v.Optional('width'): v.All(int, v.Range(min=1, max=10)),
+            v.Optional('nullPointMode'): v.All(null_point_modes),
+            v.Optional('fillBelowTo'): v.All(str),
+            v.Optional('steppedLine'): v.All(bool),
+            v.Optional('points'): v.All(bool),
+            v.Optional('pointsradius'): v.All(int, v.Range(min=1, max=5)),
+            v.Optional('stack'): v.All(v.Any(bool, 'A', 'B', 'C', 'D')),
+            v.Optional('color'): v.All(str),
+            v.Optional('yaxis'): v.All(int, v.Range(min=1, max=2)),
+            v.Optional('zindex'): v.All(int, v.Range(min=-3, max=3)),
+            v.Optional('transform'): v.All(v.Any('negative-Y')),
+            v.Optional('legend'): v.All(bool),
+        }
+        series_overrides = [series_override]
+
+        logs = {
+            v.Optional('alert'): v.All(alert_format),
+            v.Required('bars', default=False): v.All(bool),
+            v.Optional('datasource'): v.All(str),
+            v.Optional('decimals'): v.All(int),
+            v.Required('fill', default=1): v.All(int),
+            v.Optional('hideTimeOverride'): v.All(bool),
+            v.Optional('leftYAxisLabel'): v.All(str, v.Length(min=1)),
+            v.Optional('legend'): v.All(legend),
+            v.Required('lines', default=True): v.All(bool),
+            v.Required('linewidth', default=2): v.All(int),
+            v.Optional('minSpan'): v.All(int, v.Range(min=0, max=12)),
+            v.Optional('nullPointMode'): v.All(null_point_modes),
+            v.Required('percentage', default=False): v.All(bool),
+            v.Required('pointradius', default=5): v.All(int),
+            v.Required('points', default=False): v.All(bool),
+            v.Optional('repeat'): v.All(str),
+            v.Optional('rightYAxisLabel'): v.All(str, v.Length(min=1)),
+            v.Optional('seriesOverrides'): v.All(series_overrides,
+                                                 v.Length(min=1)),
+            v.Required('stack', default=False): v.All(bool),
+            v.Required('steppedLine', default=False): v.All(bool),
+            v.Required('targets', default=[]): v.All(list),
+            v.Optional('timeFrom'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
+            v.Optional('timeShift'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
+            v.Optional('tooltip'): v.All(tooltip),
+            v.Required('x-axis', default=True): v.All(bool),
+            v.Required('y-axis', default=True): v.All(bool),
+            v.Optional('y_formats'): v.All([Base.formats],
+                                           v.Length(min=2, max=2)),
+            v.Optional('yaxes'): v.All(yaxes_format, v.Length(min=2, max=2)),
+        }
+        logs.update(self.base)
+        return v.Schema(logs)

--- a/grafana_dashboards/schema/panel/singlestat.py
+++ b/grafana_dashboards/schema/panel/singlestat.py
@@ -84,6 +84,7 @@ class Singlestat(Base):
                 'min', 'max', 'avg', 'current', 'total',
                 'name', 'first', 'delta', 'diff', 'range', 'last_time'),
             v.Optional('datasource'): v.All(str),
+            v.Optional('format'): v.All(str),
             v.Optional('decimals'): v.All(int, v.Range(min=0, max=12)),
             v.Optional('gauge'): gauge,
             v.Optional('hideTimeOverride'): v.All(bool),

--- a/grafana_dashboards/schema/panel/stat.py
+++ b/grafana_dashboards/schema/panel/stat.py
@@ -53,13 +53,13 @@ class Stat(Base):
         }
 
         stat = {
-            v.Required('maxDataPoints', default=100): v.All(int),
             v.Required('targets', default=[]): v.All(list),
             v.Required('fieldConfig'): v.All(fieldConfig),
             v.Optional('options'): v.All(options),
             v.Optional('datasource'): v.All(str),
             v.Optional('timeFrom'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
             v.Optional('timeShift'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
+            v.Optional('maxDataPoints'): v.All(int),
         }
         stat.update(self.base)
         return v.Schema(stat)

--- a/grafana_dashboards/schema/panel/stat.py
+++ b/grafana_dashboards/schema/panel/stat.py
@@ -1,0 +1,65 @@
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import voluptuous as v
+
+from grafana_dashboards.schema.panel.base import Base
+
+
+class Stat(Base):
+
+    def get_schema(self):
+        reduceOptions = {
+            v.Required('values', default=False): v.All(bool),
+            v.Required('calcs', default=['last']): v.All(list),
+            v.Required('fields', default=''): v.Any(str),
+        }
+
+        thresholds = {
+            v.Required('steps'): v.All(list),
+            v.Required('mode', default='absolute'): v.Any(str),
+        }
+
+        defaults = {
+            v.Required('unit', default='short'): Base.formats,
+            v.Required('NoneValueMode', default='connected'): v.Any(str),
+            v.Required('thresholds'): v.All(thresholds),
+            v.Optional('decimals'): v.All(int),
+        }
+
+        fieldConfig = {
+            v.Required('defaults'): v.All(defaults),
+            v.Required('overrides', default=[]): v.All(list),
+        }
+
+        options = {
+            v.Required('orientation'): v.Any(str),
+            v.Required('textMode'): v.Any(str),
+            v.Required('colorMode'): v.Any(str),
+            v.Required('graphMode'): v.Any(str),
+            v.Required('justifyMode'): v.Any(str),
+            v.Optional('reduceOptions'): v.All(reduceOptions),
+        }
+
+        stat = {
+            v.Required('maxDataPoints', default=100): v.All(int),
+            v.Required('targets', default=[]): v.All(list),
+            v.Required('fieldConfig'): v.All(fieldConfig),
+            v.Optional('options'): v.All(options),
+            v.Optional('datasource'): v.All(str),
+            v.Optional('timeFrom'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
+            v.Optional('timeShift'): v.All(v.Match(r'[1-9]+[0-9]*[smhdw]')),
+        }
+        stat.update(self.base)
+        return v.Schema(stat)

--- a/grafana_dashboards/schema/panel/table.py
+++ b/grafana_dashboards/schema/panel/table.py
@@ -1,0 +1,54 @@
+# Copyright 2015 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import voluptuous as v
+
+from grafana_dashboards.schema.panel.base import Base
+
+
+class Table(Base):
+
+    def get_schema(self):
+        style = {
+            v.Optional('alias'): v.All(str),
+            v.Optional('align'): v.All(str),
+            v.Required('colors', default=[]): v.All(list),
+            v.Optional('dateFormat'): v.All(str),
+            v.Optional('decimals'): v.All(int),
+            v.Optional('mappingType'): v.All(int),
+            v.Optional('pattern'): v.All(str),
+            v.Optional('type'): v.All(str),
+            v.Optional('unit'): v.All(str),
+        }
+        styles = [style]
+
+        sort = {
+            v.Optional('col'): v.All(int),
+            v.Required('desc', default=True): v.All(bool),
+        }
+
+        table = {
+            v.Optional('fontSize'): v.All(str),
+            v.Optional('pageSize'): v.All(int),
+            v.Required('scroll', default=False): v.All(bool),
+            v.Optional('styles'): v.All(styles, v.Length(min=1)),
+            v.Required('showHeader', default=False): v.All(bool),
+            v.Optional('transform'): v.All(str),
+            v.Optional('type'): v.All(str),
+            v.Required('targets', default=[]): v.All(list),
+            v.Optional('datasource'): v.All(str),
+            v.Optional('sort'): v.All(sort),
+        }
+        table.update(self.base)
+        return v.Schema(table)

--- a/grafana_dashboards/schema/panel/table.py
+++ b/grafana_dashboards/schema/panel/table.py
@@ -47,6 +47,7 @@ class Table(Base):
             v.Optional('transform'): v.All(str),
             v.Optional('type'): v.All(str),
             v.Required('targets', default=[]): v.All(list),
+            v.Required('columns', default=[]): v.All(list),
             v.Optional('datasource'): v.All(str),
             v.Optional('sort'): v.All(sort),
         }

--- a/grafana_dashboards/schema/template/base.py
+++ b/grafana_dashboards/schema/template/base.py
@@ -66,7 +66,7 @@ class Base(object):
         self.base = {
             v.Required('name'): v.All(str, v.Length(min=1)),
             v.Required('type'): v.Any('query', 'interval', 'custom',
-                                      'datasource', 'adhoc'),
+                                      'datasource', 'adhoc', 'constant'),
         }
 
     def get_schema(self):

--- a/grafana_dashboards/schema/template/constant.py
+++ b/grafana_dashboards/schema/template/constant.py
@@ -1,0 +1,69 @@
+# Copyright 2018 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
+import voluptuous as v
+
+from grafana_dashboards.schema.template.base import Base
+
+
+class Constant(Base):
+    current = {
+        v.Required('text'): v.All(str, v.Length(min=1)),
+        v.Required('value'): v.All([str]),
+    }
+
+    def validate_options(self, options):
+        options = self._validate_options(options)
+
+        if len(options):
+            selected_options = [x for x in options if x.get('selected')]
+            # Default to first option as selected (if nothing selected)
+            if len(selected_options) == 0:
+                options[0]['selected'] = True
+
+        return options
+
+    def _validate(self, data):
+        constant = {
+            v.Required('current'): v.Any(self.current),
+            v.Required('options', default=[]): self.validate_options,
+            v.Required('query', default=''): v.All(str),
+            v.Optional('hide'): v.All(int, v.Range(min=0, max=2)),
+            v.Optional('label', default=''): v.All(str),
+
+        }
+        constant.update(self.base)
+
+        constant_options_schema = {
+            v.Required('options', default=[]): self.validate_options,
+        }
+        data = v.Schema(constant_options_schema, extra=True)(data)
+
+        # If 'query' is not supplied, compose it from the list of options.
+        if 'query' not in data:
+            query = [option['text']
+                     for option in data.get('options')
+                     if option['text'] != 'All']
+            data['query'] = ','.join(query)
+
+        if 'current' not in data:
+            selected = [option['text']
+                        for option in data.get('options')
+                        if option['selected']]
+            data['current'] = dict(text='+'.join(selected), value=selected)
+
+        return v.Schema(constant)(data)
+
+    def get_schema(self):
+        return v.Schema(self._validate)

--- a/grafana_dashboards/schema/template/constant.py
+++ b/grafana_dashboards/schema/template/constant.py
@@ -19,8 +19,8 @@ from grafana_dashboards.schema.template.base import Base
 
 class Constant(Base):
     current = {
-        v.Required('text'): v.All(str, v.Length(min=1)),
-        v.Required('value'): v.All([str]),
+        v.Optional('text'): v.All(str, v.Length(min=1)),
+        v.Optional('value'): v.All([str]),
     }
 
     def validate_options(self, options):
@@ -36,9 +36,9 @@ class Constant(Base):
 
     def _validate(self, data):
         constant = {
-            v.Required('current'): v.Any(self.current),
             v.Required('options', default=[]): self.validate_options,
             v.Required('query', default=''): v.All(str),
+            v.Optional('current'): v.Any(self.current),
             v.Optional('hide'): v.All(int, v.Range(min=0, max=2)),
             v.Optional('label', default=''): v.All(str),
 

--- a/grafana_dashboards/schema/template/datasource.py
+++ b/grafana_dashboards/schema/template/datasource.py
@@ -29,6 +29,7 @@ class Datasource(Base):
             v.Required('query', default=''): v.All(str),
             v.Required('current'): v.Any(self.current),
             v.Optional('hide'): v.All(int, v.Range(min=0, max=2)),
+            v.Optional('label', default=''): v.All(str),
         }
         query.update(self.base)
         return v.Schema(query)

--- a/grafana_dashboards/schema/template/query.py
+++ b/grafana_dashboards/schema/template/query.py
@@ -39,6 +39,7 @@ class Query(Base):
             v.Optional('hide'): v.All(int, v.Range(min=0, max=2)),
             v.Optional('regex'): v.All(str),
             v.Optional('label', default=''): v.All(str),
+            v.Optional('allValue'): v.All(str),
         }
         query.update(self.base)
         return v.Schema(query)

--- a/grafana_dashboards/schema/template/query.py
+++ b/grafana_dashboards/schema/template/query.py
@@ -32,6 +32,7 @@ class Query(Base):
                 v.All(int, v.Range(min=0, max=2)),
             v.Optional('datasource'): v.All(str),
             v.Optional('hide'): v.All(int, v.Range(min=0, max=2)),
+            v.Optional('regex'): v.All(str),
         }
         query.update(self.base)
         return v.Schema(query)

--- a/grafana_dashboards/schema/template/query.py
+++ b/grafana_dashboards/schema/template/query.py
@@ -22,9 +22,14 @@ LOG = logging.getLogger(__name__)
 
 
 class Query(Base):
+    current = {
+        v.Optional('text'): v.All(str, v.Length(min=1)),
+        v.Optional('value'): v.All([str]),
+    }
 
     def get_schema(self):
         query = {
+            v.Optional('current'): v.Any(self.current),
             v.Required('includeAll', default=False): v.All(bool),
             v.Required('multi', default=False): v.All(bool),
             v.Required('query', default=''): v.All(str),

--- a/grafana_dashboards/schema/template/query.py
+++ b/grafana_dashboards/schema/template/query.py
@@ -33,6 +33,7 @@ class Query(Base):
             v.Optional('datasource'): v.All(str),
             v.Optional('hide'): v.All(int, v.Range(min=0, max=2)),
             v.Optional('regex'): v.All(str),
+            v.Optional('label', default=''): v.All(str),
         }
         query.update(self.base)
         return v.Schema(query)


### PR DESCRIPTION
This PR adds support for the following:

1.  New log panel type
2. New stat panel type
3. Old table panel type
4. Enable custom template type
5. Add support for annotations

Apart from this it enables a lot of minor options for exisiting panel types which were not allowed earlier e.g. description for all panel types, label for datasource template etc.