### PR TITLE
Fix command output when no args are passed

### DIFF
--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -61,7 +61,7 @@ class Client(object):
             version=__version__, help="show "
             "program's version number and exit")
 
-        subparsers = parser.add_subparsers(title='commands', dest='command')
+        subparsers = parser.add_subparsers(title='commands')
         subparsers.required = True
 
         parser_delete = subparsers.add_parser('delete')

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -52,17 +52,17 @@ class Client(object):
             'server. The default used is: http://localhost:8080')
         parser.add_argument(
             '--grafana-apikey', dest='grafana_apikey',
-            help='API key to access grafana.', required=True)
+            help='API key to access grafana.')
         parser.add_argument(
-            '--grafana-folderid', dest='grafana_folderid', required=True,
+            '--grafana-folderid', dest='grafana_folderid',
             help='The id of the folder to save the dashboard in.')
         parser.add_argument(
             '--version', dest='version', action='version',
             version=__version__, help="show "
             "program's version number and exit")
 
-        subparsers = parser.add_subparsers(
-            title='commands')
+        subparsers = parser.add_subparsers(title='commands', dest='command')
+        subparsers.required = True
 
         parser_delete = subparsers.add_parser('delete')
         parser_delete.add_argument(

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -52,9 +52,9 @@ class Client(object):
             'server. The default used is: http://localhost:8080')
         parser.add_argument(
             '--grafana-apikey', dest='grafana_apikey',
-            help='API key to access grafana.')
+            help='API key to access grafana.', required=True)
         parser.add_argument(
-            '--grafana-folderid', dest='grafana_folderid',
+            '--grafana-folderid', dest='grafana_folderid', required=True,
             help='The id of the folder to save the dashboard in.')
         parser.add_argument(
             '--version', dest='version', action='version',


### PR DESCRIPTION
Currently it does this:

```
$ grafana-dashboard
Traceback (most recent call last):
  File "/usr/local/bin/grafana-dashboard", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.8/site-packages/grafana_dashboards/cmd.py", line 132, in main
    client.main()
  File "/usr/local/lib/python3.8/site-packages/grafana_dashboards/cmd.py", line 39, in main
    self.args.func()
AttributeError: 'Namespace' object has no attribute 'func'
```

So I think we just make the `command` required.