### PR TITLE
Allow setting Grafana API key by env var

### DIFF
--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -59,7 +59,10 @@ class Client(object):
             "server. The default used is: http://localhost:8080",
         )
         parser.add_argument(
-            "--grafana-apikey", dest="grafana_apikey", help="API key to access grafana."
+            "--grafana-apikey",
+            dest="grafana_apikey",
+            help="API key to access grafana.",
+            default=os.getenv("GRAFANA_API_KEY", None),
         )
         parser.add_argument(
             "--grafana-folderid",


### PR DESCRIPTION
It's bit nicer like this because then you don't have to have the API key in your command history and you can use an env var from CI without having to use a wrapper script to hide the key.