### PR TITLE
Grafana 8 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ grafana-dashboard --grafana-url https://my-grafana-host.domain.com update my-exa
 
 ```
 python3 setup.py bdist_wheel
-python3 -m pip install --force-reinstall grafyaml-1.0-py3-none-any.whl
+python3 -m pip install --force-reinstall dist/grafyaml-1.0-py3-none-any.whl
 ```
 
 ## License, history and contributors

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ grafana-dashboard --grafana-url https://my-grafana-host.domain.com update my-exa
 
 ```
 python3 setup.py bdist_wheel
-python3 -m pip install --force-reinstall ~/dev/grafyaml/dist/grafyaml-1.0-py3-none-any.whl
+python3 -m pip install --force-reinstall grafyaml-1.0-py3-none-any.whl
 ```
 
 ## License, history and contributors

--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ grafana-dashboard --grafana-url https://my-grafana-host.domain.com update my-exa
 - [examples/basic](examples/basic): A very basic example with a single dashboard
 - [examples/advanced](examples/advanced): An example showing how to create multiple dashboards using templates
 
+## Build and install from source
+
+```
+python3 setup.py bdist_wheel
+python3 -m pip install --force-reinstall ~/dev/grafyaml/dist/grafyaml-1.0-py3-none-any.whl
+```
+
 ## License, history and contributors
 
 [The LICENSE](LICENSE) is Apache License 2.0. Most of the code in this repository was initially written at [opendev.org/opendev/grafyaml](https://opendev.org/opendev/grafyaml) before being forked to here.

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -14,7 +14,6 @@
 
 import json
 
-
 from requests import exceptions
 
 from grafana_dashboards.grafana import utils

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -14,6 +14,7 @@
 
 import json
 
+
 from requests import exceptions
 
 from grafana_dashboards.grafana import utils
@@ -45,13 +46,9 @@ class Dashboard(object):
             "folderId": folder_id,
             "overwrite": overwrite,
         }
-        if not overwrite and self.is_dashboard(name):
-            raise Exception("dashboard[%s] already exists" % name)
 
         res = self.session.post(self.url, data=json.dumps(dashboard))
         res.raise_for_status()
-        if not self.is_dashboard(name):
-            raise Exception("dashboard[%s] does not exist" % name)
 
     def delete(self, name):
         """Delete a dashboard
@@ -64,8 +61,6 @@ class Dashboard(object):
         """
         url = utils.urljoin(self.url, name)
         self.session.delete(url)
-        if self.is_dashboard(name):
-            raise Exception("dashboard[%s] failed to delete" % name)
 
     def get(self, name):
         """Get a dashboard
@@ -84,18 +79,3 @@ class Dashboard(object):
             return None
 
         return res.json()
-
-    def is_dashboard(self, name):
-        """Check if a dashboard exists
-
-        :param name: URL friendly title of the dashboard
-        :type name: str
-
-        :returns: True if dashboard exists
-        :rtype: bool
-
-        """
-        res = self.get(name)
-        if res and res["meta"]["slug"] == name:
-            return True
-        return False

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -60,7 +60,8 @@ class Dashboard(object):
 
         """
         url = utils.urljoin(self.url, name)
-        self.session.delete(url)
+        res = self.session.delete(url)
+        res.raise_for_status()
 
     def get(self, name):
         """Get a dashboard

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -60,23 +60,8 @@ class Dashboard(object):
 
         """
         url = utils.urljoin(self.url, name)
-        res = self.session.delete(url)
-        res.raise_for_status()
-
-    def get(self, name):
-        """Get a dashboard
-
-        :param name: URL friendly title of the dashboard
-        :type name: str
-
-        :rtype: dict or None
-
-        """
-        url = utils.urljoin(self.url, name)
         try:
-            res = self.session.get(url)
+            res = self.session.delete(url)
             res.raise_for_status()
         except exceptions.HTTPError:
             return None
-
-        return res.json()

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -59,12 +59,6 @@ class TestCaseGrafana(TestCase):
             return True
 
         mock_requests.post("/api/dashboards/db/", json=post_callback)
-        mock_requests.get(
-            "/api/dashboards/db/new-dashboard",
-            json=DASHBOARD_NOT_FOUND,
-            status_code=404,
-        )
-
         data = {
             "dashboard": {
                 "title": "New dashboard",
@@ -72,12 +66,11 @@ class TestCaseGrafana(TestCase):
             "slug": "new-dashboard",
         }
         self.grafana.dashboard.create(name=data["slug"], data=data["dashboard"])
-        self.assertEqual(mock_requests.call_count, 3)
+        self.assertEqual(mock_requests.call_count, 1)
 
     @requests_mock.Mocker()
     def test_create_dashboard_overwrite(self, mock_requests):
         mock_requests.post("/api/dashboards/db/")
-        mock_requests.get("/api/dashboards/db/new-dashboard", json=CREATE_NEW_DASHBOARD)
         data = {
             "dashboard": {
                 "title": "New dashboard",
@@ -87,42 +80,9 @@ class TestCaseGrafana(TestCase):
         self.grafana.dashboard.create(
             name=data["slug"], data=data["dashboard"], overwrite=True
         )
-        self.assertEqual(mock_requests.call_count, 2)
-
-    @requests_mock.Mocker()
-    def test_create_dashboard_existing(self, mock_requests):
-        mock_requests.post("/api/dashboards/db/")
-        mock_requests.get("/api/dashboards/db/new-dashboard", json=CREATE_NEW_DASHBOARD)
-        data = {
-            "dashboard": {
-                "title": "New dashboard",
-            },
-            "slug": "new-dashboard",
-        }
-        self.assertRaises(
-            Exception,
-            self.grafana.dashboard.create,
-            name=data["slug"],
-            data=data["dashboard"],
-            overwrite=False,
-        )
-
         self.assertEqual(mock_requests.call_count, 1)
 
     @requests_mock.Mocker()
     def test_delete_dashboard(self, mock_requests):
         mock_requests.delete("/api/dashboards/db/new-dashboard")
-        mock_requests.get(
-            "/api/dashboards/db/new-dashboard",
-            json=DASHBOARD_NOT_FOUND,
-            status_code=404,
-        )
         self.grafana.dashboard.delete("new-dashboard")
-
-    @requests_mock.Mocker()
-    def test_delete_dashboard_failure(self, mock_requests):
-        mock_requests.delete("/api/dashboards/db/new-dashboard")
-        mock_requests.get("/api/dashboards/db/new-dashboard", json=CREATE_NEW_DASHBOARD)
-        self.assertRaises(
-            Exception, self.grafana.dashboard.delete, name="new-dashboard"
-        )


### PR DESCRIPTION
Removed is_dashboard function as it depends on grafana dashboard slug API which has been deprecated in Grafana 8. The overwrite value is anyways always set to true.