### PR TITLE
Use with-open syntax, more Pythonic

### DIFF
--- a/tests/schema/base.py
+++ b/tests/schema/base.py
@@ -30,9 +30,8 @@ class TestCase(object):
         if self.out_filename is None:
             return ""
 
-        content = open(self.out_filename, "r").read()
-
-        return content
+        with open(self.out_filename, "r") as f:
+            return f.read()
 
     def test_yaml_snippet(self):
         parser = YamlParser()


### PR DESCRIPTION
# Description

We are seeing these lines when running unit tests:

```
/Users/temporaryadmin/Desktop/grafyaml/tests/schema/base.py:33: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/temporaryadmin/Desktop/grafyaml/tests/schema/fixtures/dashboard-0026.json' mode='r' encoding='UTF-8'>
  content = open(self.out_filename, "r").read()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
./Users/temporaryadmin/Desktop/grafyaml/tests/schema/base.py:33: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/temporaryadmin/Desktop/grafyaml/tests/schema/fixtures/dashboard-0030.json' mode='r' encoding='UTF-8'>
  content = open(self.out_filename, "r").read()
ResourceWarning: Enable tracemalloc to get the object allocation traceback
  .
  .
  .
----------------------------------------------------------------------
Ran 93 tests in 0.786s

OK
```