### PR TITLE
Fix: these two config keys accept any values

### DIFF
--- a/grafana_dashboards/schema/panel/timeseries.py
+++ b/grafana_dashboards/schema/panel/timeseries.py
@@ -134,12 +134,12 @@ class Timeseries(Base):
                     {
                         v.Required("matcher"): {
                             v.Required("id", default=""): str,
-                            v.Optional("options"): v.Any(str, dict),
+                            v.Optional("options"): v.All(),
                         },
                         v.Required("properties"): [
                             {
                                 v.Required("id", default=""): str,
-                                v.Optional("value"): dict,
+                                v.Optional("value"): v.All(),
                             }
                         ],
                     }


### PR DESCRIPTION
# Description

* `v.All()` accepts any value if no argument is passed
* According to grafana's schema, these two keys accept any values (See: https://github.com/grafana/grafana/blob/main/packages/grafana-schema/src/scuemata/dashboard/dashboard.cue#L298-L305)