### PR TITLE
Chore: updated dashboard schema to support the new one

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,13 @@ Create a file, e.g. `my-example-dashboard.yaml`:
 ```yaml
 dashboard:
   title: My Dashboard
-  rows:
+  panels:
   - title: Container metrics
-    height: 500px
     panels:
     - title: Container CPU usage
       targets:
       - expr: rate(container_cpu_user_seconds_total[30s]) * 100
-      type: graph
+      type: timeseries
 ```
 
 Sync it to Grafana:

--- a/grafana_dashboards/schema/__init__.py
+++ b/grafana_dashboards/schema/__init__.py
@@ -30,4 +30,15 @@ class Schema(object):
             }
         )
 
-        return schema(data)
+        compiled: dict = schema(data)
+
+        if "dashboard" not in compiled:
+            return compiled
+
+        # FIXME: Only temporarily allow the old schema during transition period
+        if len(compiled["dashboard"]["rows"]) > 0:
+            del compiled["dashboard"]["panels"]
+        else:
+            del compiled["dashboard"]["rows"]
+
+        return compiled

--- a/grafana_dashboards/schema/dashboard.py
+++ b/grafana_dashboards/schema/dashboard.py
@@ -16,7 +16,8 @@ import voluptuous as v
 
 from grafana_dashboards.schema.links import Links
 from grafana_dashboards.schema.annotations import Annotations
-from grafana_dashboards.schema.row import Row
+from grafana_dashboards.schema.row import Row as DeprecatedRow
+from grafana_dashboards.schema.panel.row import Row
 from grafana_dashboards.schema.template import Template
 
 
@@ -37,8 +38,10 @@ class Dashboard(object):
         }
         links = Links().get_schema()
         dashboard.update(links.schema)
-        rows = Row().get_schema()
+        rows = DeprecatedRow().get_schema()
         dashboard.update(rows.schema)
+        panels = Row().get_schema()
+        dashboard.update(panels.schema)
         templating = Template().get_schema()
         dashboard.update(templating.schema)
         annotations = Annotations().get_schema()

--- a/grafana_dashboards/schema/panel/__init__.py
+++ b/grafana_dashboards/schema/panel/__init__.py
@@ -18,7 +18,6 @@ from grafana_dashboards.schema.panel.base import Base
 from grafana_dashboards.schema.panel.dashlist import Dashlist
 from grafana_dashboards.schema.panel.graph import Graph
 from grafana_dashboards.schema.panel.logs import Logs
-from grafana_dashboards.schema.panel.row import Row
 from grafana_dashboards.schema.panel.singlestat import Singlestat
 from grafana_dashboards.schema.panel.stat import Stat
 from grafana_dashboards.schema.panel.text import Text
@@ -28,6 +27,9 @@ from grafana_dashboards.schema.panel.timeseries import Timeseries
 
 
 class Panel(object):
+    def __init__(self, requiresGridPos=False):
+        self.requiresGridPos = requiresGridPos
+
     def _validate(self):
         def f(data):
             res = []
@@ -39,23 +41,23 @@ class Panel(object):
                 validate(panel)
 
                 if panel["type"] == "dashlist":
-                    schema = Dashlist().get_schema()
+                    schema = Dashlist(requiresGridPos=self.requiresGridPos).get_schema()
                 elif panel["type"] == "graph":
-                    schema = Graph().get_schema()
+                    schema = Graph(requiresGridPos=self.requiresGridPos).get_schema()
                 elif panel["type"] == "logs":
-                    schema = Logs().get_schema()
+                    schema = Logs(requiresGridPos=self.requiresGridPos).get_schema()
                 elif panel["type"] == "singlestat":
-                    schema = Singlestat().get_schema()
+                    schema = Singlestat(
+                        requiresGridPos=self.requiresGridPos
+                    ).get_schema()
                 elif panel["type"] == "stat":
-                    schema = Stat().get_schema()
+                    schema = Stat(requiresGridPos=self.requiresGridPos).get_schema()
                 elif panel["type"] == "text":
-                    schema = Text().get_schema()
-                elif panel["type"] == "row":
-                    schema = Row().get_schema()
+                    schema = Text(requiresGridPos=self.requiresGridPos).get_schema()
                 elif panel["type"] == "table":
-                    schema = Table().get_schema()
+                    schema = Table(requiresGridPos=self.requiresGridPos).get_schema()
                 elif panel["type"] == "bargauge":
-                    schema = Bargauge().get_schema()
+                    schema = Bargauge(requiresGridPos=self.requiresGridPos).get_schema()
                 elif panel["type"] == "timeseries":
                     schema = Timeseries().get_schema()
 

--- a/grafana_dashboards/schema/panel/base.py
+++ b/grafana_dashboards/schema/panel/base.py
@@ -102,9 +102,9 @@ class Base(object):
     }
 
     grid_pos = {
-        v.Optional("gridPos"): {
-            v.Required("h", default=9): v.Range(min=0, min_included=False),
-            v.Required("w", default=12): v.Range(min=0, min_included=False, max=24),
+        v.Required("gridPos"): {
+            v.Required("h", default=8): v.Range(min=0, min_included=False),
+            v.Required("w", default=8): v.Range(min=0, min_included=False, max=24),
             v.Required("x", default=0): v.Clamp(min=0),
             v.Required("y", default=0): v.Clamp(min=0),
             v.Optional("static"): bool,
@@ -137,7 +137,7 @@ class Base(object):
         },
     }
 
-    def __init__(self):
+    def __init__(self, requiresGridPos=False):
         self.base = {
             v.Required("editable", default=True): v.All(bool),
             v.Required("error", default=False): v.All(bool),
@@ -149,7 +149,6 @@ class Base(object):
                 "logs",
                 "singlestat",
                 "text",
-                "row",
                 "stat",
                 "table",
                 "bargauge",
@@ -161,6 +160,10 @@ class Base(object):
             v.Optional("height"): v.All(int),
             v.Optional("description"): v.All(str),
         }
+
+        if requiresGridPos:
+            self.base.update(__class__.grid_pos)
+            del self.base["span"]
 
     def get_schema(self):
         return v.Schema(self.base, extra=True)

--- a/grafana_dashboards/schema/panel/row.py
+++ b/grafana_dashboards/schema/panel/row.py
@@ -14,14 +14,21 @@
 
 import voluptuous as v
 
+from grafana_dashboards.schema.panel import Panel
 from grafana_dashboards.schema.panel.base import Base
 
 
 class Row(Base):
     def get_schema(self):
         row = {
-            v.Required("collapsed"): v.All(bool),
-            v.Optional("panels", default=[]): v.All([str]),
+            v.Required("title"): v.All(str, v.Length(min=1)),
+            v.Required("type", default="row"): "row",
+            v.Required("collapsed", default=True): True,
         }
-        row.update(self.base)
-        return v.Schema(row)
+        panel = Panel(requiresGridPos=True).get_schema()
+        row.update(panel.schema)
+        return v.Schema(
+            {
+                v.Required("panels", default=[]): [row],
+            }
+        )

--- a/grafana_dashboards/schema/panel/timeseries.py
+++ b/grafana_dashboards/schema/panel/timeseries.py
@@ -110,10 +110,12 @@ class Timeseries(Base):
         v.Optional("transform"): v.Any("constant", "negative-Y"),
     }
 
+    def __init__(self):
+        super(__class__, self).__init__(requiresGridPos=True)
+
     def get_schema(self):
         timeseries = {
             **Base.datasource,
-            **Base.grid_pos,
             v.Required("fieldConfig", default={"defaults": {}}): {
                 v.Required("defaults", default={}): {
                     v.Optional("displayName"): str,
@@ -156,8 +158,5 @@ class Timeseries(Base):
             v.Optional("targets"): list,
         }
         timeseries.update(self.base)
-
-        # FIXME: this is smelly
-        del timeseries["span"]
 
         return v.Schema(timeseries, extra=v.PREVENT_EXTRA)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="grafyaml",
-    version="1.0",
+    version="1.1.0",
     url="https://github.com/deliveryhero/grafyaml",
     license="Apache v2.0",
     description="A nice and easy way to template Grafana dashboards in YAML",

--- a/tests/schema/fixtures/dashboard-0001.json
+++ b/tests/schema/fixtures/dashboard-0001.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [],
+            "panels": [],
             "templating": {
                 "enabled": false,
                 "list": []

--- a/tests/schema/fixtures/dashboard-0008.json
+++ b/tests/schema/fixtures/dashboard-0008.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [],
+            "panels": [],
             "templating": {
                 "enabled": false,
                 "list": []

--- a/tests/schema/fixtures/dashboard-0014.json
+++ b/tests/schema/fixtures/dashboard-0014.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [],
+            "panels": [],
             "templating": {
                 "enabled": true,
                 "list": [

--- a/tests/schema/fixtures/dashboard-0015.json
+++ b/tests/schema/fixtures/dashboard-0015.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [],
+            "panels": [],
             "templating": {
                 "enabled": true,
                 "list": [

--- a/tests/schema/fixtures/dashboard-0024.json
+++ b/tests/schema/fixtures/dashboard-0024.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [],
+            "panels": [],
             "tags": [
                 "test_tag"
             ],

--- a/tests/schema/fixtures/dashboard-0028.json
+++ b/tests/schema/fixtures/dashboard-0028.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [],
+            "panels": [],
             "templating": {
                 "enabled": true,
                 "list": [

--- a/tests/schema/fixtures/dashboard-0032.json
+++ b/tests/schema/fixtures/dashboard-0032.json
@@ -1,7 +1,7 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [],
+            "panels": [],
             "templating": {
                 "enabled": true,
                 "list": [

--- a/tests/schema/fixtures/dashboard-0033.json
+++ b/tests/schema/fixtures/dashboard-0033.json
@@ -1,24 +1,12 @@
 {
     "dashboard": {
         "new-dashboard": {
-            "rows": [
+            "panels": [
                 {
-                    "collapse": false,
-                    "editable": true,
-                    "height": "250px",
-                    "panels": [
-                        {
-                            "collapsed": false,
-                            "editable": true,
-                            "error": false,
-                            "panels": [],
-                            "span": 12,
-                            "title": "Main",
-                            "type": "row"
-                        }
-                    ],
-                    "showTitle": false,
-                    "title": "New row"
+                    "title": "New row",
+                    "type": "row",
+                    "collapsed": true,
+                    "panels": []
                 }
             ],
             "templating": {

--- a/tests/schema/fixtures/dashboard-0033.yaml
+++ b/tests/schema/fixtures/dashboard-0033.yaml
@@ -3,10 +3,6 @@ dashboard:
     from: "2018-02-07T08:42:27.000Z"
     to: "2018-02-07T13:48:32.000Z"
   title: New dashboard
-  rows:
+  panels:
     - title: New row
-      height: 250px
-      panels:
-          - collapsed: false
-            title: Main
-            type: row
+      panels: []

--- a/tests/schema/fixtures/dashboard-0034.json
+++ b/tests/schema/fixtures/dashboard-0034.json
@@ -1,19 +1,23 @@
 {
     "dashboard": {
         "rooster-api-clone": {
-            "rows": [
+            "panels": [
                 {
+                    "type": "row",
                     "title": "Kong",
-                    "showTitle": true,
-                    "collapse": false,
-                    "editable": true,
-                    "height": "300px",
+                    "collapsed": true,
                     "panels": [
                         {
                             "datasource": {
                                 "uid": "$datasource"
                             },
                             "description": "test timeseries",
+                            "gridPos": {
+                                "w": 8,
+                                "h": 8,
+                                "x": 0,
+                                "y": 0
+                            },
                             "editable": true,
                             "error": false,
                             "fieldConfig": {

--- a/tests/schema/fixtures/dashboard-0034.yaml
+++ b/tests/schema/fixtures/dashboard-0034.yaml
@@ -8,15 +8,15 @@ dashboard:
       query: 'label_values(kong_http_status{dh_env="$env", service=~".*$app.*"}, service)'
       multi: true
       includeAll: false
-  rows:
+  panels:
     - title: Kong
-      showTitle: true
-      collapse: false
-      height: '300px'
       panels:
         - datasource:
             uid: $datasource
           description: test timeseries
+          gridPos:
+            w: 8
+            h: 8
           fieldConfig:
             defaults:
               color:

--- a/tests/schema/panels/test_timeseries.py
+++ b/tests/schema/panels/test_timeseries.py
@@ -19,6 +19,12 @@ class TestCaseTimeseries(TestCase):
                 "defaults": {},
                 "overrides": [],
             },
+            "gridPos": {
+                "w": 8,
+                "h": 8,
+                "x": 0,
+                "y": 0,
+            },
             "options": {},
         }
         self.assertThat(self.schema(defaults), testtools.matchers.Equals(defaults))

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -34,7 +34,7 @@ class TestCaseParser(TestCase):
         self.parser.parse(path)
         dashboard = {
             "foobar": {
-                "rows": [],
+                "panels": [],
                 "templating": {
                     "enabled": False,
                     "list": [],
@@ -43,7 +43,7 @@ class TestCaseParser(TestCase):
                 "title": "foobar",
             },
             "new-dashboard": {
-                "rows": [],
+                "panels": [],
                 "templating": {
                     "enabled": False,
                     "list": [],
@@ -80,7 +80,7 @@ class TestCaseParser(TestCase):
         self.parser.parse(path)
         dashboard = {
             "new-dashboard": {
-                "rows": [],
+                "panels": [],
                 "templating": {
                     "enabled": False,
                     "list": [],


### PR DESCRIPTION
# Description

I will also create a new tag for this PR. This PR unblocks https://github.com/deliveryhero/logistics-dashboards/pull/294

* Resolves [OGSYS-4964](https://jira.deliveryhero.com/browse/OGSYS-4964)

Changes:
* Updated dashboard schema, the old row schema is now deprecated but is still supported.
* This PR temporarily supports both schemas to allow a transition period.
* Panels in the new schema must have gridPos
* Updated unit tests