### PR TITLE
Allow row collapse option to be overridden in dashboards

### DIFF
--- a/grafana_dashboards/schema/panel/row.py
+++ b/grafana_dashboards/schema/panel/row.py
@@ -23,7 +23,7 @@ class Row(Base):
         row = {
             v.Required("title"): v.All(str, v.Length(min=1)),
             v.Required("type", default="row"): "row",
-            v.Required("collapsed", default=True): True,
+            v.Required("collapsed", default=True): bool,
         }
         panel = Panel(usingNewSchema=True).get_schema()
         row.update(panel.schema)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="grafyaml",
-    version="1.3.0",
+    version="1.3.1",
     url="https://github.com/deliveryhero/grafyaml",
     license="Apache v2.0",
     description="A nice and easy way to template Grafana dashboards in YAML",


### PR DESCRIPTION
Update default value of collapse option for rows so the default behavior can be overridden in dashboards