### PR TITLE
fix: removed ordinal from/added symlog into scaleDistribution

### DIFF
--- a/grafana_dashboards/schema/dashboard.py
+++ b/grafana_dashboards/schema/dashboard.py
@@ -24,7 +24,6 @@ from grafana_dashboards.schema.panel import Panel
 
 class Dashboard(object):
     def get_schema(self):
-
         dashboard = {
             v.Required("timezone", default="utc"): v.Any("browser", "utc"),
             v.Required("title"): v.All(str, v.Length(min=1)),

--- a/grafana_dashboards/schema/panel/graph.py
+++ b/grafana_dashboards/schema/panel/graph.py
@@ -21,7 +21,6 @@ from grafana_dashboards.schema.panel.base import Base
 
 class Graph(Base):
     def get_schema(self):
-
         alert_format = {
             # could enforce "evaulator"/"operator"/"query" on this...
             v.Required("conditions"): v.All(list),

--- a/grafana_dashboards/schema/panel/logs.py
+++ b/grafana_dashboards/schema/panel/logs.py
@@ -21,7 +21,6 @@ from grafana_dashboards.schema.panel.base import Base
 
 class Logs(Base):
     def get_schema(self):
-
         alert_format = {
             # could enforce "evaulator"/"operator"/"query" on this...
             v.Required("conditions"): v.All(list),

--- a/grafana_dashboards/schema/panel/timeseries.py
+++ b/grafana_dashboards/schema/panel/timeseries.py
@@ -67,7 +67,7 @@ class Timeseries(Base):
         v.Optional("axisSoftMax"): v.Number(),
         v.Optional("axisGridShow"): bool,
         v.Optional("scaleDistribution"): {
-            v.Required("type"): v.Any("linear", "log", "ordinal"),
+            v.Required("type"): v.Any("linear", "log", "symlog"),
             v.Optional("log"): v.Number(),
         },
     }

--- a/grafana_dashboards/schema/template/datasource.py
+++ b/grafana_dashboards/schema/template/datasource.py
@@ -18,7 +18,6 @@ from grafana_dashboards.schema.template.base import Base
 
 
 class Datasource(Base):
-
     current = {
         v.Required("text"): v.All(str, v.Length(min=1)),
         v.Required("value"): v.All(str, v.Length(min=1)),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="grafyaml",
-    version="1.3.1",
+    version="1.4.0",
     url="https://github.com/deliveryhero/grafyaml",
     license="Apache v2.0",
     description="A nice and easy way to template Grafana dashboards in YAML",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -17,7 +17,6 @@ from tests.base import TestCase
 
 
 class TestCaseCache(TestCase):
-
     dashboard = {
         "hello-world": "2095312189753de6ad47dfe20cbe97ec",
     }


### PR DESCRIPTION
## Description

* Removed ordinal from and added `symlog` into scaleDistribution.
* Noticed this during testing that ordinal is no longer an option/choice in Grafana
* Also fixed broken test due to lint error