### PR TITLE
LOGMLE - Add logs options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ grafana-dashboard --grafana-url https://my-grafana-host.domain.com update my-exa
 ## Build and install from source
 
 ```
+python3 -m pip install wheel
 python3 setup.py bdist_wheel
 python3 -m pip install --force-reinstall dist/grafyaml-1.0-py3-none-any.whl
 ```

--- a/grafana_dashboards/schema/panel/logs.py
+++ b/grafana_dashboards/schema/panel/logs.py
@@ -60,8 +60,23 @@ class Logs(Base):
         }
 
         null_point_modes = v.Any("connected", "null", "null as zero")
-        value_types = v.Any("individual", "cumulative")
 
+        options = {
+            v.Optional("dedupStrategy", default="none"): v.All(
+                str, "none", "exact", "numbers", "signature"
+            ),
+            v.Optional("enableLogDetails", default=True): v.All(bool),
+            v.Optional("prettifyLogMessage", default=False): v.All(bool),
+            v.Optional("showCommonLabels", default=False): v.All(bool),
+            v.Optional("showLabels", default=False): v.All(bool),
+            v.Optional("showTime", default=False): v.All(bool),
+            v.Optional("sortOrder", default="Descending"): v.All(
+                str, "Ascending", "Descending"
+            ),
+            v.Optional("wrapLogMessage", default=False): v.All(bool),
+        }
+
+        value_types = v.Any("individual", "cumulative")
         tooltip = {
             v.Required("query_as_alias", default=True): v.All(bool),
             v.Required("shared", default=True): v.All(bool),
@@ -102,6 +117,7 @@ class Logs(Base):
             v.Required("linewidth", default=2): v.All(int),
             v.Optional("minSpan"): v.All(int, v.Range(min=0, max=12)),
             v.Optional("nullPointMode"): v.All(null_point_modes),
+            v.Optional("options", default={}): v.All(options),
             v.Required("percentage", default=False): v.All(bool),
             v.Required("pointradius", default=5): v.All(int),
             v.Required("points", default=False): v.All(bool),

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="grafyaml",
-    version="1.4.1",
+    version="1.4.2",
     url="https://github.com/deliveryhero/grafyaml",
     license="Apache v2.0",
     description="A nice and easy way to template Grafana dashboards in YAML",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -14,7 +14,7 @@
 
 import os
 
-import mock
+from unittest import mock
 
 from grafana_dashboards import builder
 from tests.base import TestCase

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,6 @@ deps =
     coverage>=3.6
     python-subunit>=0.0.18
     requests-mock>=0.6.0
-    mock>=1.2
     oslotest>=1.2.0
     testrepository>=0.0.18
     testscenarios>=0.4


### PR DESCRIPTION
This PR allows one to change the options of the logs panel.  I would like the change the sortOrder in one of the panels that we use, but I added all available options according to the documentation.

- [see panel docs](https://grafana.com/docs/grafana/latest/developers/kinds/composable/logs/panelcfg/schema-reference/)
- I also removed `mock` as a requirement as this has been part of the python standard library since python 3.3