### PR TITLE
feat: implement handling duplicate dashboards in same folder

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,25 @@
+## Description
+
+_A concise summary of the changes._
+
+## Why?
+
+_The reason for this change._
+
+## How?
+
+_A brief explanation of how the changes were implemented._
+
+## Checklist
+
+- [ ] I have performed a self-review of my own code
+- [ ] I have added or updated relevant tests
+- [ ] I have updated the documentation (if necessary)
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Other (please specify):

--- a/.github/workflows/.releaserc.json
+++ b/.github/workflows/.releaserc.json
@@ -1,0 +1,11 @@
+{
+  "verifyConditions": ["@semantic-release/changelog", "@semantic-release/git"],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    "@semantic-release/git",
+    "@semantic-release/github"
+  ],
+  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "main"]
+}

--- a/.github/workflows/.releaserc.json
+++ b/.github/workflows/.releaserc.json
@@ -7,5 +7,5 @@
     "@semantic-release/git",
     "@semantic-release/github"
   ],
-  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "main"]
+  "branches": ["+([0-9])?(.{+([0-9]),x}).x", "master"]
 }

--- a/.github/workflows/pull_request_check.yaml
+++ b/.github/workflows/pull_request_check.yaml
@@ -14,11 +14,10 @@ jobs:
         uses: transferwise/actions-pr-checker@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_TITLE_CONTAINS_PATTERN: '^(chore|fix|feat): (?:(?:#\d+[, ]*)+(?:: ))?.*'
+          PR_TITLE_CONTAINS_PATTERN: "^(chore|fix|feat): .*"
           SUCCESS_COMMENT: Now that's a good PR!
           PR_COMMENT: |
             The title of your PR does not match the expected format. It **must** always contain the following types: chore, fix, feat, docs, style, refactor or test.
-            Note: 'hotfix' can be used without a ticket, but the proper reason is needed.
 
             ✅ Correct examples:
             * chore: my cool PR

--- a/.github/workflows/pull_request_check.yaml
+++ b/.github/workflows/pull_request_check.yaml
@@ -15,7 +15,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_TITLE_CONTAINS_PATTERN: "^(chore|fix|feat): .*"
-          SUCCESS_COMMENT: Now that's a good PR!
           PR_COMMENT: |
             The title of your PR does not match the expected format. It **must** always contain the following types: chore, fix, feat, docs, style, refactor or test.
 

--- a/.github/workflows/pull_request_check.yaml
+++ b/.github/workflows/pull_request_check.yaml
@@ -1,0 +1,33 @@
+name: PR checker
+
+on:
+  pull_request:
+    branches: [master, main]
+    types: [opened, edited, labeled, unlabeled, synchronize]
+
+jobs:
+  pr-checker:
+    name: Validate pull request
+    runs-on: [ubuntu-latest]
+    steps:
+      - name: Run check
+        uses: transferwise/actions-pr-checker@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_TITLE_CONTAINS_PATTERN: '^(chore|fix|feat): (?:(?:#\d+[, ]*)+(?:: ))?.*'
+          SUCCESS_COMMENT: Now that's a good PR!
+          PR_COMMENT: |
+            The title of your PR does not match the expected format. It **must** always contain the following types: chore, fix, feat, docs, style, refactor or test.
+            Note: 'hotfix' can be used without a ticket, but the proper reason is needed.
+
+            ✅ Correct examples:
+            * chore: my cool PR
+            * chore: #1234, #1234: chore with issue number
+            * fix: my cool bugfix
+            * fix: #1234, #1234: fix with issue number
+            * feat: my cool bugfix
+            * feat: #1234, #1234: with issue number
+
+            ❌ Wrong examples:
+            * My cool feature
+            * WAL-0 my cool feature

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,45 @@
+name: Semantic Release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  semantic-release:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    name: Semantic Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "lts/*"
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        id: semantic # Need an `id` for output variables
+        with:
+          semantic_version: 17
+          extra_plugins: |
+            @semantic-release/changelog@5
+            @semantic-release/exec@5
+            @semantic-release/git@9
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Do something when a new release published
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          echo ${{ steps.semantic.outputs.new_release_version }}
+          echo ${{ steps.semantic.outputs.new_release_major_version }}
+          echo ${{ steps.semantic.outputs.new_release_minor_version }}
+          echo ${{ steps.semantic.outputs.new_release_patch_version }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,6 @@ on:
 
 jobs:
   semantic-release:
-    if: "!contains(github.event.head_commit.message, '[skip ci]')"
     name: Semantic Release
     runs-on: ubuntu-latest
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ __pycache__
 examples/advanced/rendered_dashboards/*.yaml
 
 /venv3
-.venv/
+*venv/
+*vscode

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ examples/advanced/rendered_dashboards/*.yaml
 /venv3
 *venv/
 *vscode
+*conf

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ examples/advanced/rendered_dashboards/*.yaml
 
 /venv3
 *venv/
-*vscode
+*vscode/
 *conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,4 +28,4 @@ RUN /output/install-from-bindep
 # may optionally supply GRAFANA_APIKEY.
 # Mount the dashboards at /grafana.
 
-ENTRYPOINT /usr/local/bin/grafana-dashboard --debug --grafana-url="${GRAFANA_URL}" ${GRAFANA_APIKEY:+--grafana-apikey "$GRAFANA_APIKEY"} update /grafana
+ENTRYPOINT /usr/local/bin/grafyaml --debug --grafana-url="${GRAFANA_URL}" ${GRAFANA_APIKEY:+--grafana-apikey "$GRAFANA_APIKEY"} update /grafana

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Sync it to Grafana:
 
 ```
 export GRAFANA_API_KEY="API_KEY_HERE"
-grafana-dashboard --grafana-url https://my-grafana-host.domain.com update my-example-dashboard.yaml
+grafyaml --grafana-url https://my-grafana-host.domain.com update my-example-dashboard.yaml
 ```
 
 ## More examples

--- a/examples/advanced/render.py
+++ b/examples/advanced/render.py
@@ -10,12 +10,13 @@ from typing import Dict, Any, List, Tuple, Optional
 row_templates_cache: Dict[str, Optional[Dict[str, Any]]] = {}
 
 # Configure logging
-logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
 
 def read_configs(
-    apps_file: str,
-    base_template_name: str,
-    template_dir: str
+    apps_file: str, base_template_name: str, template_dir: str
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     """
     Reads and loads the applications configuration and the base dashboard template.
@@ -34,18 +35,22 @@ def read_configs(
         yaml.YAMLError: If there's an error parsing the YAML files.
         ValueError: If the loaded YAML does not have the expected top-level structure.
     """
-    logging.info(f"Reading configuration from '{apps_file}' and base template from '{base_template_name}' in '{template_dir}'")
+    logging.info(
+        f"Reading configuration from '{apps_file}' and base template from '{base_template_name}' in '{template_dir}'"
+    )
 
     # Load applications configuration
     try:
-        with open(apps_file, 'r') as f:
+        with open(apps_file, "r") as f:
             parsed_input = yaml.safe_load(f) or {}
         if not isinstance(parsed_input, dict):
             raise ValueError(
                 f"Input file '{apps_file}' does not contain a dictionary at the top level. "
                 f"Found {type(parsed_input).__name__}."
             )
-        logging.info(f"Successfully loaded applications config from '{apps_file}'. Found {len(parsed_input)} applications.")
+        logging.info(
+            f"Successfully loaded applications config from '{apps_file}'. Found {len(parsed_input)} applications."
+        )
     except FileNotFoundError:
         logging.error(f"Applications config file not found: '{apps_file}'")
         raise
@@ -56,22 +61,29 @@ def read_configs(
     # Load base dashboard template
     base_dashboard_path = os.path.join(template_dir, base_template_name)
     try:
-        with open(base_dashboard_path, 'r') as f:
+        with open(base_dashboard_path, "r") as f:
             base_dashboard_template = yaml.safe_load(f) or {}
         if not isinstance(base_dashboard_template, dict):
-             raise ValueError(
+            raise ValueError(
                 f"Base dashboard template '{base_dashboard_path}' does not contain a dictionary at the top level. "
                 f"Found {type(base_dashboard_template).__name__}."
             )
-        logging.info(f"Successfully loaded base dashboard template from '{base_dashboard_path}'.")
+        logging.info(
+            f"Successfully loaded base dashboard template from '{base_dashboard_path}'."
+        )
     except FileNotFoundError:
-        logging.error(f"Base dashboard template file not found: '{base_dashboard_path}'")
+        logging.error(
+            f"Base dashboard template file not found: '{base_dashboard_path}'"
+        )
         raise
     except yaml.YAMLError:
-        logging.error(f"Error parsing base dashboard template file: '{base_dashboard_path}'")
+        logging.error(
+            f"Error parsing base dashboard template file: '{base_dashboard_path}'"
+        )
         raise
 
     return parsed_input, base_dashboard_template
+
 
 def build_app_rows(
     app_name: str,
@@ -94,11 +106,11 @@ def build_app_rows(
     app_rows_list: List[Dict[str, Any]] = []
 
     if not isinstance(row_names, list):
-         logging.warning(
-             f"App '{app_name}' has invalid 'rows' structure. Expected list, "
-             f"got {type(row_names).__name__}. No rows will be added from config."
-         )
-         return [] # Return empty list early
+        logging.warning(
+            f"App '{app_name}' has invalid 'rows' structure. Expected list, "
+            f"got {type(row_names).__name__}. No rows will be added from config."
+        )
+        return []  # Return empty list early
 
     logging.info(f"Processing {len(row_names)} row(s) for app '{app_name}'...")
 
@@ -115,7 +127,7 @@ def build_app_rows(
         if row_name not in row_templates_cache:
             row_template_path = os.path.join(template_dir, f"{row_name}.yaml")
             try:
-                with open(row_template_path, 'r') as f:
+                with open(row_template_path, "r") as f:
                     loaded_data = yaml.safe_load(f)
                     # Cache the loaded data (could be None if file was empty)
                     if "rows" in loaded_data and isinstance(loaded_data, dict):
@@ -124,40 +136,46 @@ def build_app_rows(
                         logging.error(
                             f"Row {row_name} is missing top level key rows, skipping"
                         )
-                logging.debug(f"Successfully loaded template '{row_name}.yaml' into cache.")
+                logging.debug(
+                    f"Successfully loaded template '{row_name}.yaml' into cache."
+                )
             except FileNotFoundError:
                 logging.warning(
                     f"Row template file '{row_template_path}' not found for app '{app_name}'. "
                     f"Skipping this row."
                 )
-                row_templates_cache[row_name] = None # Cache None to prevent re-attempting load
+                row_templates_cache[row_name] = (
+                    None  # Cache None to prevent re-attempting load
+                )
             except yaml.YAMLError as e:
                 logging.warning(
                     f"Error parsing row template file '{row_template_path}' for app '{app_name}': {e}. "
                     f"Skipping this row."
                 )
-                row_templates_cache[row_name] = None # Cache None on error
+                row_templates_cache[row_name] = None  # Cache None on error
             except Exception as e:
                 logging.warning(
                     f"An unexpected error occurred loading row template '{row_template_path}' for app '{app_name}': {e}. "
                     f"Skipping this row."
                 )
-                row_templates_cache[row_name] = None # Cache None on error
+                row_templates_cache[row_name] = None  # Cache None on error
 
         # --- Get the loaded template data from cache ---
         # Check if loading previously failed (cache value is None)
         row_data = row_templates_cache.get(row_name)
         if row_data is None:
-             # Warning already printed during loading, just continue
-             continue
+            # Warning already printed during loading, just continue
+            continue
 
         # --- Validate the loaded data is a dictionary and looks like a row (has 'panels' list) ---
         # This check assumes a valid single-row template MUST be a dictionary
         # AND contain a 'panels' key which is a list. Adjust validation if needed.
         if isinstance(row_data, dict) and isinstance(row_data.get("panels"), list):
-             # Append the single valid row dictionary to the list
+            # Append the single valid row dictionary to the list
             app_rows_list.append(row_data)
-            logging.debug(f"Appended row from template '{row_name}.yaml' for app '{app_name}'.")
+            logging.debug(
+                f"Appended row from template '{row_name}.yaml' for app '{app_name}'."
+            )
         else:
             logging.warning(
                 f"Row template '{row_name}.yaml' for app '{app_name}' has invalid structure. "
@@ -166,10 +184,9 @@ def build_app_rows(
 
     return app_rows_list
 
+
 def process_templating_section(
-    dashboard_data: Dict[str, Any],
-    app_config: Dict[str, Any],
-    app_name: str
+    dashboard_data: Dict[str, Any], app_config: Dict[str, Any], app_name: str
 ) -> Dict[str, Any]:
     """
     Processes and merges templating configurations from the base dashboard
@@ -186,22 +203,23 @@ def process_templating_section(
     # Use a dictionary for base templates for faster lookups/updates
     base_templates_list = dashboard_data.get("templating", [])
     if not isinstance(base_templates_list, list):
-         logging.warning(
+        logging.warning(
             f"Base dashboard template has invalid 'templating' structure for app '{app_name}'. "
             f"Expected list. Using empty list."
-         )
-         base_templates_list = []
+        )
+        base_templates_list = []
 
     base_templates_dict = {
         tmpl.get("name"): tmpl
-        for tmpl in base_templates_list if isinstance(tmpl, dict) and tmpl.get("name")
+        for tmpl in base_templates_list
+        if isinstance(tmpl, dict) and tmpl.get("name")
     }
 
     # Add/Update 'app' template (ensuring it exists)
     app_template_config = base_templates_dict.get("app")
     if not isinstance(app_template_config, dict):
         app_template_config = {"name": "app", "type": "constant", "hide": 0}
-        base_templates_dict["app"] = app_template_config # Add/replace in dict
+        base_templates_dict["app"] = app_template_config  # Add/replace in dict
 
     # Safely update the 'app' template values
     app_template_config["query"] = str(app_name)
@@ -217,12 +235,16 @@ def process_templating_section(
             f"App '{app_name}' has invalid 'templating' structure. Expected list, "
             f"got {type(app_templates_list).__name__}. No app-specific templates will be added."
         )
-        app_templates_list = [] # Use empty list
+        app_templates_list = []  # Use empty list
 
     for template in app_templates_list:
         if isinstance(template, dict) and template.get("name"):
-            base_templates_dict[template["name"]] = template # Add or overwrite using name as key
-            logging.debug(f"Added/Overrode template '{template.get('name')}' for '{app_name}'.")
+            base_templates_dict[template["name"]] = (
+                template  # Add or overwrite using name as key
+            )
+            logging.debug(
+                f"Added/Overrode template '{template.get('name')}' for '{app_name}'."
+            )
         else:
             logging.warning(
                 f"App '{app_name}' contains an invalid template definition: {template}. "
@@ -235,10 +257,9 @@ def process_templating_section(
 
     return dashboard_data
 
+
 def write_dashboard_file(
-    app_name: str,
-    output_dir: str,
-    dashboard_data: Dict[str, Any]
+    app_name: str, output_dir: str, dashboard_data: Dict[str, Any]
 ) -> None:
     """
     Writes the generated dashboard dictionary to a YAML file.
@@ -258,7 +279,9 @@ def write_dashboard_file(
     except (IOError, yaml.YAMLError) as e:
         logging.error(f"Error writing output file '{output_file_path}': {e}")
     except Exception as e:
-        logging.error(f"An unexpected error occurred while writing output file '{output_file_path}': {e}")
+        logging.error(
+            f"An unexpected error occurred while writing output file '{output_file_path}': {e}"
+        )
 
 
 def main():
@@ -279,7 +302,7 @@ def main():
         logging.info(f"Ensured output directory '{output_dir}' exists.")
     except OSError as e:
         logging.error(f"Failed to create output directory '{output_dir}': {e}")
-        return # Cannot proceed if output directory cannot be created
+        return  # Cannot proceed if output directory cannot be created
 
     # --- Speed & Safety: Load base configuration and templates once ---
     try:
@@ -288,12 +311,13 @@ def main():
         )
     except (FileNotFoundError, yaml.YAMLError, ValueError) as e:
         logging.error(f"Failed to load initial configuration files. Exiting. {e}")
-        return # Critical error, cannot proceed
-
+        return  # Critical error, cannot proceed
 
     # --- Process each application ---
     if not apps_config:
-        logging.warning("No applications found in the input configuration. Nothing to generate.")
+        logging.warning(
+            "No applications found in the input configuration. Nothing to generate."
+        )
 
     for app_name, app_config in apps_config.items():
         # Ensure app_config is a dictionary and app_name is usable
@@ -325,10 +349,12 @@ def main():
         logging.debug(f"Set dashboard title to '{app_name}'.")
 
         # --- Process Templating ---
-        dashboard_data = process_templating_section(dashboard_data, app_config, app_name)
+        dashboard_data = process_templating_section(
+            dashboard_data, app_config, app_name
+        )
 
         # --- Build and Assign Rows ---
-        rows_config = app_config.get("rows", []) # Get rows list safely from app config
+        rows_config = app_config.get("rows", [])  # Get rows list safely from app config
 
         dashboard_data["panels"] = build_app_rows(
             app_name,
@@ -338,16 +364,17 @@ def main():
 
         # --- Override Tags if specified ---
         app_tags = app_config.get("tags")
-        if app_tags is not None: # Allows setting tags to None/empty list in input
-            if isinstance(app_tags, list) or app_tags is None: # Ensure it's a list or None
-               dashboard_data["tags"] = app_tags
-               logging.debug(f"Overrode tags for '{app_name}': {app_tags}")
+        if app_tags is not None:  # Allows setting tags to None/empty list in input
+            if (
+                isinstance(app_tags, list) or app_tags is None
+            ):  # Ensure it's a list or None
+                dashboard_data["tags"] = app_tags
+                logging.debug(f"Overrode tags for '{app_name}': {app_tags}")
             else:
-               logging.warning(
-                   f"App '{app_name}' has invalid 'tags' structure: {app_tags}. "
-                   f"Expected list or null. Skipping tag override."
+                logging.warning(
+                    f"App '{app_name}' has invalid 'tags' structure: {app_tags}. "
+                    f"Expected list or null. Skipping tag override."
                 )
-
 
         # --- Write Output File ---
         # Pass the dictionary that represents the content *under* the top-level 'dashboard' key

--- a/examples/advanced/render.py
+++ b/examples/advanced/render.py
@@ -2,71 +2,358 @@
 
 import yaml
 import os
+import copy
+import logging
+from typing import Dict, Any, List, Tuple, Optional
 
+# Cache for loaded row templates across all applications
+row_templates_cache: Dict[str, Optional[Dict[str, Any]]] = {}
 
-def find_template_index(template, template_list):
-    index = 0
-    for item in template_list:
-        if item["name"] == template["name"]:
-            return index
+# Configure logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def read_configs(
+    apps_file: str,
+    base_template_name: str,
+    template_dir: str
+) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """
+    Reads and loads the applications configuration and the base dashboard template.
+
+    Args:
+        apps_file: Path to the main applications YAML file (e.g., "apps.yaml").
+        base_template_name: Name of the base dashboard template file (e.g., "base_dashboard.yaml").
+        template_dir: Directory containing template files (e.g., "templates").
+
+    Returns:
+        A tuple containing the parsed applications dictionary and the parsed
+        base dashboard template dictionary.
+
+    Raises:
+        FileNotFoundError: If required input files are not found.
+        yaml.YAMLError: If there's an error parsing the YAML files.
+        ValueError: If the loaded YAML does not have the expected top-level structure.
+    """
+    logging.info(f"Reading configuration from '{apps_file}' and base template from '{base_template_name}' in '{template_dir}'")
+
+    # Load applications configuration
+    try:
+        with open(apps_file, 'r') as f:
+            parsed_input = yaml.safe_load(f) or {}
+        if not isinstance(parsed_input, dict):
+            raise ValueError(
+                f"Input file '{apps_file}' does not contain a dictionary at the top level. "
+                f"Found {type(parsed_input).__name__}."
+            )
+        logging.info(f"Successfully loaded applications config from '{apps_file}'. Found {len(parsed_input)} applications.")
+    except FileNotFoundError:
+        logging.error(f"Applications config file not found: '{apps_file}'")
+        raise
+    except yaml.YAMLError:
+        logging.error(f"Error parsing applications config file: '{apps_file}'")
+        raise
+
+    # Load base dashboard template
+    base_dashboard_path = os.path.join(template_dir, base_template_name)
+    try:
+        with open(base_dashboard_path, 'r') as f:
+            base_dashboard_template = yaml.safe_load(f) or {}
+        if not isinstance(base_dashboard_template, dict):
+             raise ValueError(
+                f"Base dashboard template '{base_dashboard_path}' does not contain a dictionary at the top level. "
+                f"Found {type(base_dashboard_template).__name__}."
+            )
+        logging.info(f"Successfully loaded base dashboard template from '{base_dashboard_path}'.")
+    except FileNotFoundError:
+        logging.error(f"Base dashboard template file not found: '{base_dashboard_path}'")
+        raise
+    except yaml.YAMLError:
+        logging.error(f"Error parsing base dashboard template file: '{base_dashboard_path}'")
+        raise
+
+    return parsed_input, base_dashboard_template
+
+def build_app_rows(
+    app_name: str,
+    row_names: List[str],
+    template_dir: str,
+) -> List[Dict[str, Any]]:
+    """
+    Builds the list of row dictionaries for a specific application by loading
+    and validating row template files. Caches loaded templates.
+
+    Args:
+        app_name: The name of the current application being processed.
+        row_names: A list of row template names specified for this application.
+        template_dir: Directory containing template files.
+        row_templates_cache: A dictionary used to cache loaded row templates.
+
+    Returns:
+        A list of valid row dictionaries for the application.
+    """
+    app_rows_list: List[Dict[str, Any]] = []
+
+    if not isinstance(row_names, list):
+         logging.warning(
+             f"App '{app_name}' has invalid 'rows' structure. Expected list, "
+             f"got {type(row_names).__name__}. No rows will be added from config."
+         )
+         return [] # Return empty list early
+
+    logging.info(f"Processing {len(row_names)} row(s) for app '{app_name}'...")
+
+    for row_name in row_names:
+        if not isinstance(row_name, str) or not row_name:
+            logging.warning(
+                f"App '{app_name}' has invalid or empty row name '{row_name}'. "
+                f"Expected non-empty string. Skipping."
+            )
+            continue
+
+        # --- Load row template if not already loaded into cache ---
+        # Use None as a cache value to signify loading failed previously
+        if row_name not in row_templates_cache:
+            row_template_path = os.path.join(template_dir, f"{row_name}.yaml")
+            try:
+                with open(row_template_path, 'r') as f:
+                    loaded_data = yaml.safe_load(f)
+                    # Cache the loaded data (could be None if file was empty)
+                    if "rows" in loaded_data and isinstance(loaded_data, dict):
+                        row_templates_cache[row_name] = loaded_data["rows"]
+                    else:
+                        logging.error(
+                            f"Row {row_name} is missing top level key rows, skipping"
+                        )
+                logging.debug(f"Successfully loaded template '{row_name}.yaml' into cache.")
+            except FileNotFoundError:
+                logging.warning(
+                    f"Row template file '{row_template_path}' not found for app '{app_name}'. "
+                    f"Skipping this row."
+                )
+                row_templates_cache[row_name] = None # Cache None to prevent re-attempting load
+            except yaml.YAMLError as e:
+                logging.warning(
+                    f"Error parsing row template file '{row_template_path}' for app '{app_name}': {e}. "
+                    f"Skipping this row."
+                )
+                row_templates_cache[row_name] = None # Cache None on error
+            except Exception as e:
+                logging.warning(
+                    f"An unexpected error occurred loading row template '{row_template_path}' for app '{app_name}': {e}. "
+                    f"Skipping this row."
+                )
+                row_templates_cache[row_name] = None # Cache None on error
+
+        # --- Get the loaded template data from cache ---
+        # Check if loading previously failed (cache value is None)
+        row_data = row_templates_cache.get(row_name)
+        if row_data is None:
+             # Warning already printed during loading, just continue
+             continue
+
+        # --- Validate the loaded data is a dictionary and looks like a row (has 'panels' list) ---
+        # This check assumes a valid single-row template MUST be a dictionary
+        # AND contain a 'panels' key which is a list. Adjust validation if needed.
+        if isinstance(row_data, dict) and isinstance(row_data.get("panels"), list):
+             # Append the single valid row dictionary to the list
+            app_rows_list.append(row_data)
+            logging.debug(f"Appended row from template '{row_name}.yaml' for app '{app_name}'.")
         else:
-            index = index + 1
-    index = -1
-    return index
+            logging.warning(
+                f"Row template '{row_name}.yaml' for app '{app_name}' has invalid structure. "
+                f"Expected a dictionary with a 'panels' list at the top level. Skipping."
+            )
+
+    return app_rows_list
+
+def process_templating_section(
+    dashboard_data: Dict[str, Any],
+    app_config: Dict[str, Any],
+    app_name: str
+) -> Dict[str, Any]:
+    """
+    Processes and merges templating configurations from the base dashboard
+    and the application-specific config. Modifies dashboard_data in place.
+
+    Args:
+        dashboard_data: The dictionary representing the 'dashboard' key in the base template.
+                        Modified in place.
+        app_config: The configuration dictionary for the current application.
+        app_name: The name of the current application.
+    """
+    logging.debug(f"Processing templating for app '{app_name}'")
+
+    # Use a dictionary for base templates for faster lookups/updates
+    base_templates_list = dashboard_data.get("templating", [])
+    if not isinstance(base_templates_list, list):
+         logging.warning(
+            f"Base dashboard template has invalid 'templating' structure for app '{app_name}'. "
+            f"Expected list. Using empty list."
+         )
+         base_templates_list = []
+
+    base_templates_dict = {
+        tmpl.get("name"): tmpl
+        for tmpl in base_templates_list if isinstance(tmpl, dict) and tmpl.get("name")
+    }
+
+    # Add/Update 'app' template (ensuring it exists)
+    app_template_config = base_templates_dict.get("app")
+    if not isinstance(app_template_config, dict):
+        app_template_config = {"name": "app", "type": "constant", "hide": 0}
+        base_templates_dict["app"] = app_template_config # Add/replace in dict
+
+    # Safely update the 'app' template values
+    app_template_config["query"] = str(app_name)
+    app_template_config.setdefault("current", {})
+    app_template_config["current"]["text"] = str(app_name)
+    app_template_config["current"]["value"] = str(app_name)
+    logging.debug(f"Updated 'app' template for '{app_name}'.")
+
+    # Add or override base templates with app-specific templates
+    app_templates_list = app_config.get("templating", [])
+    if not isinstance(app_templates_list, list):
+        logging.warning(
+            f"App '{app_name}' has invalid 'templating' structure. Expected list, "
+            f"got {type(app_templates_list).__name__}. No app-specific templates will be added."
+        )
+        app_templates_list = [] # Use empty list
+
+    for template in app_templates_list:
+        if isinstance(template, dict) and template.get("name"):
+            base_templates_dict[template["name"]] = template # Add or overwrite using name as key
+            logging.debug(f"Added/Overrode template '{template.get('name')}' for '{app_name}'.")
+        else:
+            logging.warning(
+                f"App '{app_name}' contains an invalid template definition: {template}. "
+                f"Expected a dictionary with a 'name' key. Skipping."
+            )
+
+    # Convert the templates dictionary back to a list for the final dashboard structure
+    dashboard_data["templating"] = list(base_templates_dict.values())
+    logging.debug(f"Finished processing templating for app '{app_name}'.")
+
+    return dashboard_data
+
+def write_dashboard_file(
+    app_name: str,
+    output_dir: str,
+    dashboard_data: Dict[str, Any]
+) -> None:
+    """
+    Writes the generated dashboard dictionary to a YAML file.
+
+    Args:
+        app_name: The name of the application.
+        output_dir: The output directory.
+        dashboard_data: The dictionary representing the dashboard structure.
+    """
+    output_file_path = os.path.join(output_dir, f"{app_name}.yaml")
+    logging.info(f"Writing dashboard to '{output_file_path}'")
+    try:
+        with open(output_file_path, "w") as f:
+            # Use default_flow_style=False for a more human-readable output
+            yaml.dump({"dashboard": dashboard_data}, f, default_flow_style=False)
+        logging.info(f"Successfully generated '{output_file_path}'")
+    except (IOError, yaml.YAMLError) as e:
+        logging.error(f"Error writing output file '{output_file_path}': {e}")
+    except Exception as e:
+        logging.error(f"An unexpected error occurred while writing output file '{output_file_path}': {e}")
 
 
 def main():
-    filename = "apps.yaml"
-    template_dir_name = "templates"
+    """
+    Main function to generate Grafana dashboards.
+    """
+    # --- Configuration ---
+    apps_filename = "apps.yaml"
+    template_dir = "templates"
+    output_dir = "rendered_dashboards"
+    base_dashboard_template_name = "base_dashboard.yaml"
 
-    dashboard_list = open(filename)
-    parsed_input = yaml.load(dashboard_list, Loader=yaml.FullLoader)
+    logging.info("Starting dashboard generation process.")
 
-    # Generate dashboard for each application
-    for appname in parsed_input.keys():
-        base_dashboard_filename = template_dir_name + "/base_dashboard.yaml"
-        base_dashboard_file = open(base_dashboard_filename)
-        dashboard = yaml.load(base_dashboard_file, Loader=yaml.FullLoader)
+    # --- Safety: Create output directory if it doesn't exist ---
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+        logging.info(f"Ensured output directory '{output_dir}' exists.")
+    except OSError as e:
+        logging.error(f"Failed to create output directory '{output_dir}': {e}")
+        return # Cannot proceed if output directory cannot be created
 
-        # Set correct name for dashboard
-        dashboard["dashboard"]["title"] = appname
-        # Add app name as constant template
-        for app_template in dashboard["dashboard"]["templating"]:
-            if app_template["name"] == "app":
-                app_template["query"] = appname
-                app_template["current"]["text"] = appname
-                app_template["current"]["value"] = appname
-                break
+    # --- Speed & Safety: Load base configuration and templates once ---
+    try:
+        apps_config, base_dashboard_raw = read_configs(
+            apps_filename, base_dashboard_template_name, template_dir
+        )
+    except (FileNotFoundError, yaml.YAMLError, ValueError) as e:
+        logging.error(f"Failed to load initial configuration files. Exiting. {e}")
+        return # Critical error, cannot proceed
 
-        # Add rows from app_dashboards to generated dashboard
-        rows = []
-        for row in parsed_input[appname]["rows"]:
-            template_file_name = template_dir_name + "/" + row + ".yaml"
-            row_template = open(template_file_name)
-            parsed_row = yaml.load(row_template, Loader=yaml.FullLoader)["rows"]
-            rows.append(parsed_row)
 
-        # Add or override the default templates with the templates
-        # specified in the app dashboards file
-        if "templating" in parsed_input[appname]:
-            for template in parsed_input[appname]["templating"]:
-                index = find_template_index(
-                    template, dashboard["dashboard"]["templating"]
+    # --- Process each application ---
+    if not apps_config:
+        logging.warning("No applications found in the input configuration. Nothing to generate.")
+
+    for app_name, app_config in apps_config.items():
+        # Ensure app_config is a dictionary and app_name is usable
+        if not isinstance(app_name, str) or not isinstance(app_config, dict):
+            logging.warning(
+                f"Skipping invalid configuration entry. Expected key (app name) to be string "
+                f"and value to be dictionary. Got {type(app_name).__name__}: {app_name} "
+                f"- {type(app_config).__name__}."
+            )
+            continue
+
+        logging.info(f"Processing application '{app_name}'")
+
+        # --- Accuracy & Speed: Deep copy the base template for each app ---
+        # We need a deep copy so modifications for one app don't affect others
+        dashboard_full_structure = copy.deepcopy(base_dashboard_raw)
+
+        # Access the main dashboard data dictionary safely
+        dashboard_data = dashboard_full_structure.get("dashboard")
+        if not isinstance(dashboard_data, dict):
+            logging.warning(
+                f"Base dashboard template structure invalid for app '{app_name}'. "
+                f"Missing or invalid 'dashboard' key. Skipping generation for this app."
+            )
+            continue
+
+        # --- Accuracy: Set correct name for dashboard ---
+        dashboard_data["title"] = str(app_name)
+        logging.debug(f"Set dashboard title to '{app_name}'.")
+
+        # --- Process Templating ---
+        dashboard_data = process_templating_section(dashboard_data, app_config, app_name)
+
+        # --- Build and Assign Rows ---
+        rows_config = app_config.get("rows", []) # Get rows list safely from app config
+
+        dashboard_data["panels"] = build_app_rows(
+            app_name,
+            rows_config,
+            template_dir,
+        )
+
+        # --- Override Tags if specified ---
+        app_tags = app_config.get("tags")
+        if app_tags is not None: # Allows setting tags to None/empty list in input
+            if isinstance(app_tags, list) or app_tags is None: # Ensure it's a list or None
+               dashboard_data["tags"] = app_tags
+               logging.debug(f"Overrode tags for '{app_name}': {app_tags}")
+            else:
+               logging.warning(
+                   f"App '{app_name}' has invalid 'tags' structure: {app_tags}. "
+                   f"Expected list or null. Skipping tag override."
                 )
-                if index == -1:
-                    dashboard["dashboard"]["templating"].append(template)
-                else:
-                    dashboard["dashboard"]["templating"][index] = template
 
-        # Override tags if specified
-        if "tags" in parsed_input[appname]:
-            dashboard["dashboard"]["tags"] = parsed_input[appname]["tags"]
 
-        dashboard["dashboard"]["rows"] = rows
+        # --- Write Output File ---
+        # Pass the dictionary that represents the content *under* the top-level 'dashboard' key
+        write_dashboard_file(app_name, output_dir, dashboard_data)
 
-        output_file_name = "rendered_dashboards/" + "/" + appname + ".yaml"
-        output_file = open(output_file_name, "w")
-        output_file.write(yaml.dump(dashboard))
+    logging.info("Dashboard generation process completed.")
 
 
 if __name__ == "__main__":

--- a/grafana_dashboards/builder.py
+++ b/grafana_dashboards/builder.py
@@ -32,6 +32,7 @@ class Builder(object):
             url=config.get("grafana", "url"), key=config.get("grafana", "apikey")
         )
         self.parser = YamlParser()
+        self.overwrite = config.getboolean("grafana", "overwrite")
 
     def delete(self, path):
         self.load_files(path)
@@ -92,7 +93,7 @@ class Builder(object):
             data, md5 = self.parser.get_dashboard(name)
             if self.cache.has_changed(name, md5):
                 self.grafana.dashboard.create(
-                    data=data, overwrite=True, folder_id=self.folder_id
+                    data=data, overwrite=self.overwrite, folder_id=self.folder_id
                 )
                 self.cache.set(name, md5)
             else:

--- a/grafana_dashboards/builder.py
+++ b/grafana_dashboards/builder.py
@@ -92,7 +92,7 @@ class Builder(object):
             data, md5 = self.parser.get_dashboard(name)
             if self.cache.has_changed(name, md5):
                 self.grafana.dashboard.create(
-                    name, data, overwrite=True, folder_id=self.folder_id
+                    data=data, overwrite=True, folder_id=self.folder_id
                 )
                 self.cache.set(name, md5)
             else:

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -38,7 +38,10 @@ class Client(object):
         self.args.func()
 
     def parse_arguments(self):
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(
+            prog="grafyaml",
+            description="A tool for managing Grafana dashboards as YAML."
+        )
         parser.add_argument(
             "--config-file",
             dest="config",
@@ -76,6 +79,13 @@ class Client(object):
             version=__version__,
             help="show " "program's version number and exit",
         )
+        parser.add_argument(
+            "--overwrite",
+            dest="overwrite",
+            action="store_true",
+            default=os.getenv("GRAFANA_API_KEY", False),
+            help="allow overwriting dashboards",
+        )
 
         subparsers = parser.add_subparsers(title="commands")
         subparsers.required = True
@@ -98,6 +108,10 @@ class Client(object):
         )
         parser_validate.set_defaults(func=self.validate)
 
+        if len(sys.argv) == 1:
+            parser.print_help()
+            sys.exit(0)
+
         self.args = parser.parse_args()
 
     def read_config(self):
@@ -116,6 +130,9 @@ class Client(object):
         if self.args.grafana_folderid:
             self.config.set("grafana", "folderid", self.args.grafana_folderid)
             LOG.debug("Grafana Folderid overridden")
+        if self.args.overwrite:
+            self.config.set("grafana", "overwrite", self.args.overwrite)
+            LOG.debug("Grafana overwrite overridden")
 
     def setup_logging(self):
         if self.args.debug:

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -40,7 +40,7 @@ class Client(object):
     def parse_arguments(self):
         parser = argparse.ArgumentParser(
             prog="grafyaml",
-            description="A tool for managing Grafana dashboards as YAML."
+            description="A tool for managing Grafana dashboards as YAML.",
         )
         parser.add_argument(
             "--config-file",

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -80,10 +80,9 @@ class Client(object):
             help="show " "program's version number and exit",
         )
         parser.add_argument(
-            "--overwrite",
+            "--disable-overwrite",
             dest="overwrite",
-            action="store_true",
-            default=os.getenv("GRAFANA_API_KEY", False),
+            action="store_false",
             help="allow overwriting dashboards",
         )
 
@@ -130,9 +129,8 @@ class Client(object):
         if self.args.grafana_folderid:
             self.config.set("grafana", "folderid", self.args.grafana_folderid)
             LOG.debug("Grafana Folderid overridden")
-        if self.args.overwrite:
-            self.config.set("grafana", "overwrite", self.args.overwrite)
-            LOG.debug("Grafana overwrite overridden")
+
+        self.config.set("grafana", "overwrite", str(self.args.overwrite))
 
     def setup_logging(self):
         if self.args.debug:
@@ -143,7 +141,11 @@ class Client(object):
     def update(self):
         LOG.info("Updating schema in %s", self.args.path)
         builder = Builder(self.config)
-        builder.update(self.args.path)
+        try:
+            builder.update(self.args.path)
+        except ValueError as e:
+            LOG.info(f"Error: {e}")
+            sys.exit(1)
 
     def validate(self):
         LOG.info("Validating schema in %s", self.args.path)

--- a/grafana_dashboards/config.py
+++ b/grafana_dashboards/config.py
@@ -27,3 +27,4 @@ class Config(ConfigParser.ConfigParser):
         self.set("grafana", "apikey", "")
         self.set("grafana", "url", "http://localhost:8080")
         self.set("grafana", "folderid", "0")
+        self.set("grafana", "overwrite", "false")

--- a/grafana_dashboards/config.py
+++ b/grafana_dashboards/config.py
@@ -27,4 +27,4 @@ class Config(ConfigParser.ConfigParser):
         self.set("grafana", "apikey", "")
         self.set("grafana", "url", "http://localhost:8080")
         self.set("grafana", "folderid", "0")
-        self.set("grafana", "overwrite", "false")
+        self.set("grafana", "overwrite", "true")

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -13,7 +13,6 @@
 # under the License.
 
 import json
-import uuid
 from requests import exceptions
 from grafana_dashboards.grafana import utils
 from typing import List, Dict
@@ -25,11 +24,9 @@ class Dashboard(object):
         self.search_url = utils.urljoin(base_url, "api/search?type=dash-db")
         self.session = session
 
-    def create(self, name: str, data: Dict, overwrite: bool=False, folder_id: int=0)-> None:
+    def create(self, data: Dict, overwrite: bool = False, folder_id: int = 0) -> None:
         """Create a new dashboard
 
-        :param name: URL friendly title of the dashboard
-        :type name: str
         :param data: Dashboard model
         :type data: dict
         :param overwrite: Overwrite existing dashboard with newer version or
@@ -41,19 +38,21 @@ class Dashboard(object):
         :raises Exception: if dashboard already exists
 
         """
-        title = data.get('title')
+        title = str(data.get("title"))
         dashboards = self.find_dashboards_by_title(title, folder_id)
 
         if len(dashboards) > 1 and overwrite:
-            uids = [d.get('uid') for d in dashboards]
-            error_msg = f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_id}. "\
+            uids = [d.get("uid") for d in dashboards]
+            error_msg = (
+                f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_id}. "
                 f"Cannot overwrite. UIDs: {uids}"
+            )
             raise ValueError(error_msg)
 
         # If there is already a dashboard with the same name in the same folder, use its UID
         if dashboards and overwrite:
-            uid = dashboards[0].get('uid')
-            data['uid'] = uid
+            uid = dashboards[0].get("uid")
+            data["uid"] = uid
 
         dashboard = {
             "dashboard": data,
@@ -86,7 +85,7 @@ class Dashboard(object):
         response.raise_for_status()
         return response.json()
 
-    def find_dashboards_by_title(self, title: str, folder_id: int = None) -> List[Dict]:
+    def find_dashboards_by_title(self, title: str, folder_id: int = 0) -> List[Dict]:
         """Find all dashboards with a specific title and optionally in a specific folder
 
         Args:
@@ -98,6 +97,11 @@ class Dashboard(object):
         """
         dashboards = self.list_dashboards()
 
-        dashboards = list(filter(lambda x: x.get('title') == title and x.get('folderId') == folder_id, dashboards))
+        dashboards = list(
+            filter(
+                lambda x: x.get("title") == title and x.get("folderId") == folder_id,
+                dashboards,
+            )
+        )
 
         return dashboards

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -16,7 +16,6 @@ import json
 from requests import exceptions
 from grafana_dashboards.grafana import utils
 from typing import List, Dict
-from sys import exit
 
 
 class Dashboard(object):
@@ -80,19 +79,22 @@ class Dashboard(object):
         except exceptions.HTTPError:
             return None
 
-    def search_dashboards(self, title: str, limit:int = 1000) -> List[Dict]:
-        """Get a list of all dashboards"""
+    def search_dashboards(self, title: str, limit: int = 1000) -> List[Dict]:
+        """Search all dashboards with specific title
+
+        Args:
+            title: The title of the dashboards to find
+            limit: Max Number of dashboards per page
+
+        Returns:
+            List of dashboard objects that match the criteria
+
+        """
         dashboards = []
         page = 1
 
         while True:
-            params = {
-                "type":
-                "dash-db",
-                "query": title,
-                "limit": limit,
-                "page": page,
-            }
+            params = {"type": "dash-db", "query": title, "limit": limit, "page": page}
 
             response = self.session.get(self.search_url, params=params)
             response.raise_for_status()
@@ -110,10 +112,12 @@ class Dashboard(object):
             if limit is None or len(data) < limit:
                 break
 
+            page += 1
+
         return dashboards
 
     def find_dashboards_by_title(self, title: str, folder_id: int = 0) -> List[Dict]:
-        """Find all dashboards with a specific title and optionally in a specific folder
+        """Find all dashboards with a specific title and in a specific folder
 
         Args:
             title: The title of the dashboards to find

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,10 @@ setup(
         "grafana_dashboards/schema/template",
     ],
     entry_points={
-        "console_scripts": ["grafana-dashboard=grafana_dashboards.cmd:main"],
+        "console_scripts": [
+            "grafana-dashboard=grafana_dashboards.cmd:main",
+            "grafyaml=grafana_dashboards.cmd:main"
+        ],
     },
     install_requires=[
         "dogpile.cache",

--- a/setup.py
+++ b/setup.py
@@ -16,8 +16,8 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "grafana-dashboard=grafana_dashboards.cmd:main",
-            "grafyaml=grafana_dashboards.cmd:main"
+            "grafana-dashboard=grafana_dashboards.cmd:main",  # backward compatibility
+            "grafyaml=grafana_dashboards.cmd:main",
         ],
     },
     install_requires=[

--- a/tests/cmd/base.py
+++ b/tests/cmd/base.py
@@ -32,7 +32,7 @@ class TestCase(TestCase):
             sys.stdout = six.StringIO()
             sys.stderr = six.StringIO()
             argv = [
-                "grafana-dashboards",
+                "grafyaml",
                 "--config-file=%s" % self.configfile,
             ]
             argv += argstr.split()

--- a/tests/cmd/test_delete.py
+++ b/tests/cmd/test_delete.py
@@ -22,8 +22,8 @@ from tests.cmd.base import TestCase
 class TestCaseDelete(TestCase):
     def test_delete_without_path(self):
         required = [
-            r".*?^usage: grafana-dashboards delete \[-h\] path",
-            r".*?^grafana-dashboards delete: error: (too few arguments|the "
+            r".*?^usage: grafyaml delete \[-h\] path",
+            r".*?^grafyaml delete: error: (too few arguments|the "
             r"following arguments are required: path)",
         ]
         stdout, stderr = self.shell("delete", exitcodes=[2])

--- a/tests/cmd/test_update.py
+++ b/tests/cmd/test_update.py
@@ -22,8 +22,8 @@ from tests.cmd.base import TestCase
 class TestCaseUpdate(TestCase):
     def test_update_without_path(self):
         required = [
-            r".*?^usage: grafana-dashboards update \[-h\] path",
-            r".*?^grafana-dashboards update: error: (too few arguments|the "
+            r".*?^usage: grafyaml update \[-h\] path",
+            r".*?^grafyaml update: error: (too few arguments|the "
             r"following arguments are required: path)",
         ]
         stdout, stderr = self.shell("update", exitcodes=[2])

--- a/tests/cmd/test_validate.py
+++ b/tests/cmd/test_validate.py
@@ -109,8 +109,8 @@ class TestCaseValidate(TestCase):
 
     def test_validate_without_path(self):
         required = [
-            r".*?^usage: grafana-dashboards validate \[-h\] path",
-            r".*?^grafana-dashboards validate: error: (too few arguments|the "
+            r".*?^usage: grafyaml validate \[-h\] path",
+            r".*?^grafyaml validate: error: (too few arguments|the "
             r"following arguments are required: path)",
         ]
         stdout, stderr = self.shell("validate", exitcodes=[2])


### PR DESCRIPTION
## Description

Grafyaml, a tool that leverages dashboard slugs for targeted updates, faces a challenge with Grafana 12. The shift to UID-based identification leads to the unintended duplication of dashboards when Grafyaml attempts to update existing ones.

## Why?

Grafyaml's ability to create and update is vital for dashboard stability and reliability. Without it, Grafana 12's UID preference would cause duplicate dashboards, leading to monitoring inconsistencies.

## How?

To mitigate dashboard duplication caused by Grafana 12's UID preference, we've enforced a constraint of one unique dashboard name per folder. Our update process searches for dashboards by title within the specified folder. If multiple entries are found and overwrite is enabled, an exception is triggered to prevent unintended modifications. If a single entry is found, its UID is retrieved and used to target the update operation.

## Other changes
- add --disable-overwrite for disable overwriting
- use grafyaml consistently for the cli, keeps old grafana-dashboard for backward compatibility
- add release and pr checking to the CI

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have added or updated relevant tests
- [x] I have updated the documentation (if necessary)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update