### PR TITLE
fix: improve error handling when parsing files

### DIFF
--- a/grafana_dashboards/builder.py
+++ b/grafana_dashboards/builder.py
@@ -63,7 +63,12 @@ class Builder(object):
                 files_to_process.append(path)
 
         for fn in files_to_process:
-            self.parser.parse(fn)
+            try:
+                self.parser.parse(fn)
+            except Exception as e:
+                LOG.error("Error parsing %s: %s", fn, e)
+                raise e
+
 
     def update(self, path):
         self.load_files(path)

--- a/grafana_dashboards/builder.py
+++ b/grafana_dashboards/builder.py
@@ -69,7 +69,6 @@ class Builder(object):
                 LOG.error("Error parsing %s: %s", fn, e)
                 raise e
 
-
     def update(self, path):
         self.load_files(path)
         datasources = self.parser.data.get("datasource", {})

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -30,12 +30,16 @@ class Client(object):
         builder = Builder(self.config)
         builder.delete(self.args.path)
 
-    def main(self):
+    def main(self)-> int:
         self.parse_arguments()
         self.setup_logging()
         self.read_config()
-
-        self.args.func()
+        try:
+            self.args.func()
+        except Exception as e:
+            LOG.error("%s: ERROR: %s" % (self.args.path, e))
+            return 1
+        return 0
 
     def parse_arguments(self):
         parser = argparse.ArgumentParser(
@@ -164,5 +168,4 @@ class Client(object):
 
 def main():
     client = Client()
-    client.main()
-    sys.exit(0)
+    sys.exit(client.main())

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -30,7 +30,7 @@ class Client(object):
         builder = Builder(self.config)
         builder.delete(self.args.path)
 
-    def main(self)-> int:
+    def main(self) -> int:
         self.parse_arguments()
         self.setup_logging()
         self.read_config()


### PR DESCRIPTION
## Description

Improve error handling when parsing files

## Why?

When using Grafyaml, if you provide a directory to the update flag, the tool will indicate that an error occurred during parsing or validation. However, it won't specify which particular file within that directory caused the failure. This isn't a problem if you're only updating a single file, but it makes troubleshooting difficult when you're working with multiple files in a directory.

## How?

We've enhanced error handling in the load_files method. Now, when parsing or validation fails, we log the filename and the specific issue. Additionally, Grafyaml now gracefully processes exceptions instead of crashing.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have added or updated relevant tests
- [x] I have updated the documentation (if necessary)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify):
