### PR TITLE
chore: Adds option of repeat panel with repeat direction to timeseries panel schema

### DIFF
--- a/grafana_dashboards/schema/panel/timeseries.py
+++ b/grafana_dashboards/schema/panel/timeseries.py
@@ -153,8 +153,8 @@ class Timeseries(Base):
                 **Base.options_with_tooltip,
                 **Base.options_with_text_formatting,
             },
-            v.Optional("repeat"): v.All(str),
-            v.Optional("repeatDirection"): v.All(str),
+            v.Optional("repeat"): str,
+            v.Optional("repeatDirection"): v.Any("h", "v"),
             # TODO: Grafana hasn't defined a proper schema yet
             # See https://github.com/grafana/grafana/blob/v8.5.0/packages/grafana-schema/src/scuemata/dashboard/dashboard.cue#L164
             v.Optional("targets"): list,

--- a/grafana_dashboards/schema/panel/timeseries.py
+++ b/grafana_dashboards/schema/panel/timeseries.py
@@ -153,6 +153,8 @@ class Timeseries(Base):
                 **Base.options_with_tooltip,
                 **Base.options_with_text_formatting,
             },
+            v.Optional("repeat"): v.All(str),
+            v.Optional("repeatDirection"): v.All(str),
             # TODO: Grafana hasn't defined a proper schema yet
             # See https://github.com/grafana/grafana/blob/v8.5.0/packages/grafana-schema/src/scuemata/dashboard/dashboard.cue#L164
             v.Optional("targets"): list,

--- a/tests/schema/panels/test_timeseries.py
+++ b/tests/schema/panels/test_timeseries.py
@@ -1,5 +1,6 @@
 import testtools.matchers
 from testtools import TestCase
+import voluptuous as v
 
 from grafana_dashboards.schema.panel.timeseries import Timeseries
 
@@ -46,3 +47,23 @@ class TestCaseTimeseries(TestCase):
             "repeatDirection": "h",
         }
         self.assertThat(self.schema(panel), testtools.matchers.Equals(panel))
+
+    def test_repeat_direction_invalid(self):
+        panel = {
+            "type": "timeseries",
+            "title": "test timeseries ($var)",
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": [],
+            },
+            "gridPos": {
+                "w": 12,
+                "h": 8,
+                "x": 0,
+                "y": 0,
+            },
+            "options": {},
+            "repeat": "my_variable",
+            "repeatDirection": "x",
+        }
+        self.assertRaises(v.Invalid, self.schema, panel)

--- a/tests/schema/panels/test_timeseries.py
+++ b/tests/schema/panels/test_timeseries.py
@@ -26,3 +26,23 @@ class TestCaseTimeseries(TestCase):
             "options": {},
         }
         self.assertThat(self.schema(defaults), testtools.matchers.Equals(defaults))
+
+    def test_repeat(self):
+        panel = {
+            "type": "timeseries",
+            "title": "test timeseries ($var)",
+            "fieldConfig": {
+                "defaults": {},
+                "overrides": [],
+            },
+            "gridPos": {
+                "w": 12,
+                "h": 8,
+                "x": 0,
+                "y": 0,
+            },
+            "options": {},
+            "repeat": "my_variable",
+            "repeatDirection": "h",
+        }
+        self.assertThat(self.schema(panel), testtools.matchers.Equals(panel))


### PR DESCRIPTION
## Description

_A concise summary of the changes._

## Why?

Allows the usage of the Repeat panel functionality in Grafana. This enables the panel being repeated by something in the query (or argument) 

## How?

_A brief explanation of how the changes were implemented._

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have added or updated relevant tests
- [ ] I have updated the documentation (if necessary)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify):
