### PR TITLE
fix: Minor fixes to schemas

### DIFF
--- a/grafana_dashboards/schema/panel/bargauge.py
+++ b/grafana_dashboards/schema/panel/bargauge.py
@@ -58,7 +58,9 @@ class Bargauge(Base):
             v.Required("targets", default=[]): v.All(list),
             v.Optional("fieldConfig"): v.All(fieldConfig),
             v.Optional("options"): v.All(options),
-            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
+            v.Optional("datasource"): v.Any(
+                str, {v.Optional("type"): str, v.Optional("uid"): str}
+            ),
             v.Optional("timeFrom"): v.All(v.Match(r"[1-9]+[0-9]*[smhdw]")),
             v.Optional("timeShift"): v.All(v.Match(r"[1-9]+[0-9]*[smhdw]")),
             v.Optional("maxDataPoints"): v.All(int),

--- a/grafana_dashboards/schema/panel/bargauge.py
+++ b/grafana_dashboards/schema/panel/bargauge.py
@@ -58,7 +58,7 @@ class Bargauge(Base):
             v.Required("targets", default=[]): v.All(list),
             v.Optional("fieldConfig"): v.All(fieldConfig),
             v.Optional("options"): v.All(options),
-            v.Optional("datasource"): v.All(str),
+            v.Optional("datasource"): v.Any(str, dict),
             v.Optional("timeFrom"): v.All(v.Match(r"[1-9]+[0-9]*[smhdw]")),
             v.Optional("timeShift"): v.All(v.Match(r"[1-9]+[0-9]*[smhdw]")),
             v.Optional("maxDataPoints"): v.All(int),

--- a/grafana_dashboards/schema/panel/bargauge.py
+++ b/grafana_dashboards/schema/panel/bargauge.py
@@ -58,7 +58,7 @@ class Bargauge(Base):
             v.Required("targets", default=[]): v.All(list),
             v.Optional("fieldConfig"): v.All(fieldConfig),
             v.Optional("options"): v.All(options),
-            v.Optional("datasource"): v.Any(str, dict),
+            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
             v.Optional("timeFrom"): v.All(v.Match(r"[1-9]+[0-9]*[smhdw]")),
             v.Optional("timeShift"): v.All(v.Match(r"[1-9]+[0-9]*[smhdw]")),
             v.Optional("maxDataPoints"): v.All(int),

--- a/grafana_dashboards/schema/panel/gauge.py
+++ b/grafana_dashboards/schema/panel/gauge.py
@@ -64,7 +64,7 @@ class Gauge(Base):
             v.Required("targets", default=[]): v.All(list),
             v.Optional("fieldConfig"): v.All(fieldConfig),
             v.Optional("options"): v.All(options),
-            v.Optional("datasource"): v.Any(str, dict),
+            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
             v.Optional("gridPos"): v.All(gridPos),
         }
         bargauge.update(self.base)

--- a/grafana_dashboards/schema/panel/gauge.py
+++ b/grafana_dashboards/schema/panel/gauge.py
@@ -35,8 +35,8 @@ class Gauge(Base):
                     v.Required("palette", default="cool"): v.Any(str),
                 }
             ),
-            v.Optional("min", default="0"): v.Any(int),
-            v.Optional("max", default="0"): v.Any(int),
+            v.Optional("min"): v.Number(),
+            v.Optional("max"): v.Number(),
             v.Optional("unit"): v.Any(str),
             v.Optional("links"): v.Any(list),
             v.Optional("decimal", default=2): v.Any(int),
@@ -64,7 +64,7 @@ class Gauge(Base):
             v.Required("targets", default=[]): v.All(list),
             v.Optional("fieldConfig"): v.All(fieldConfig),
             v.Optional("options"): v.All(options),
-            v.Optional("datasource"): v.All(str),
+            v.Optional("datasource"): v.Any(str, dict),
             v.Optional("gridPos"): v.All(gridPos),
         }
         bargauge.update(self.base)

--- a/grafana_dashboards/schema/panel/gauge.py
+++ b/grafana_dashboards/schema/panel/gauge.py
@@ -64,7 +64,9 @@ class Gauge(Base):
             v.Required("targets", default=[]): v.All(list),
             v.Optional("fieldConfig"): v.All(fieldConfig),
             v.Optional("options"): v.All(options),
-            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
+            v.Optional("datasource"): v.Any(
+                str, {v.Optional("type"): str, v.Optional("uid"): str}
+            ),
             v.Optional("gridPos"): v.All(gridPos),
         }
         bargauge.update(self.base)

--- a/grafana_dashboards/schema/panel/logs.py
+++ b/grafana_dashboards/schema/panel/logs.py
@@ -107,7 +107,7 @@ class Logs(Base):
         logs = {
             v.Optional("alert"): v.All(alert_format),
             v.Required("bars", default=False): v.All(bool),
-            v.Optional("datasource"): v.Any(str, dict),
+            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
             v.Optional("decimals"): v.All(int),
             v.Required("fill", default=1): v.All(int),
             v.Optional("hideTimeOverride"): v.All(bool),

--- a/grafana_dashboards/schema/panel/logs.py
+++ b/grafana_dashboards/schema/panel/logs.py
@@ -107,7 +107,9 @@ class Logs(Base):
         logs = {
             v.Optional("alert"): v.All(alert_format),
             v.Required("bars", default=False): v.All(bool),
-            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
+            v.Optional("datasource"): v.Any(
+                str, {v.Optional("type"): str, v.Optional("uid"): str}
+            ),
             v.Optional("decimals"): v.All(int),
             v.Required("fill", default=1): v.All(int),
             v.Optional("hideTimeOverride"): v.All(bool),

--- a/grafana_dashboards/schema/panel/logs.py
+++ b/grafana_dashboards/schema/panel/logs.py
@@ -62,16 +62,16 @@ class Logs(Base):
         null_point_modes = v.Any("connected", "null", "null as zero")
 
         options = {
-            v.Optional("dedupStrategy", default="none"): v.All(
-                str, "none", "exact", "numbers", "signature"
+            v.Optional("dedupStrategy", default="none"): v.Any(
+                "none", "exact", "numbers", "signature"
             ),
             v.Optional("enableLogDetails", default=True): v.All(bool),
             v.Optional("prettifyLogMessage", default=False): v.All(bool),
             v.Optional("showCommonLabels", default=False): v.All(bool),
             v.Optional("showLabels", default=False): v.All(bool),
             v.Optional("showTime", default=False): v.All(bool),
-            v.Optional("sortOrder", default="Descending"): v.All(
-                str, "Ascending", "Descending"
+            v.Optional("sortOrder", default="Descending"): v.Any(
+                "Ascending", "Descending"
             ),
             v.Optional("wrapLogMessage", default=False): v.All(bool),
         }
@@ -107,7 +107,7 @@ class Logs(Base):
         logs = {
             v.Optional("alert"): v.All(alert_format),
             v.Required("bars", default=False): v.All(bool),
-            v.Optional("datasource"): v.All(str),
+            v.Optional("datasource"): v.Any(str, dict),
             v.Optional("decimals"): v.All(int),
             v.Required("fill", default=1): v.All(int),
             v.Optional("hideTimeOverride"): v.All(bool),

--- a/grafana_dashboards/schema/template/__init__.py
+++ b/grafana_dashboards/schema/template/__init__.py
@@ -34,7 +34,7 @@ class Template(object):
 
     def _validate(self):
         def f(data):
-            res = self.defaults
+            res = {"enabled": False, "list": []}
             if not isinstance(data, list):
                 raise v.Invalid("Should be a list")
 

--- a/grafana_dashboards/schema/template/__init__.py
+++ b/grafana_dashboards/schema/template/__init__.py
@@ -40,20 +40,20 @@ class Template(object):
 
             for template in data:
                 res["enabled"] = True
-                validate = Base().get_schema()
-                validate(template)
+                schema = Base().get_schema()
+                schema(template)
 
                 if template["type"] == "query":
                     schema = Query().get_schema()
-                if template["type"] == "interval":
+                elif template["type"] == "interval":
                     schema = Interval().get_schema()
-                if template["type"] == "custom":
+                elif template["type"] == "custom":
                     schema = Custom().get_schema()
-                if template["type"] == "datasource":
+                elif template["type"] == "datasource":
                     schema = Datasource().get_schema()
-                if template["type"] == "adhoc":
+                elif template["type"] == "adhoc":
                     schema = Adhoc().get_schema()
-                if template["type"] == "textbox":
+                elif template["type"] == "textbox":
                     schema = Textbox().get_schema()
 
                 res["list"].append(schema(template))

--- a/grafana_dashboards/schema/template/query.py
+++ b/grafana_dashboards/schema/template/query.py
@@ -34,7 +34,7 @@ class Query(Base):
             v.Required("multi", default=False): v.All(bool),
             v.Required("query", default=""): v.Any(str, dict),
             v.Required("refresh", default=1): v.All(int, v.Range(min=0, max=2)),
-            v.Optional("datasource"): v.All(str),
+            v.Optional("datasource"): v.Any(str, dict),
             v.Optional("hide"): v.All(int, v.Range(min=0, max=2)),
             v.Optional("regex"): v.All(str),
             v.Optional("label", default=""): v.All(str),

--- a/grafana_dashboards/schema/template/query.py
+++ b/grafana_dashboards/schema/template/query.py
@@ -34,7 +34,7 @@ class Query(Base):
             v.Required("multi", default=False): v.All(bool),
             v.Required("query", default=""): v.Any(str, dict),
             v.Required("refresh", default=1): v.All(int, v.Range(min=0, max=2)),
-            v.Optional("datasource"): v.Any(str, dict),
+            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
             v.Optional("hide"): v.All(int, v.Range(min=0, max=2)),
             v.Optional("regex"): v.All(str),
             v.Optional("label", default=""): v.All(str),

--- a/grafana_dashboards/schema/template/query.py
+++ b/grafana_dashboards/schema/template/query.py
@@ -34,7 +34,9 @@ class Query(Base):
             v.Required("multi", default=False): v.All(bool),
             v.Required("query", default=""): v.Any(str, dict),
             v.Required("refresh", default=1): v.All(int, v.Range(min=0, max=2)),
-            v.Optional("datasource"): v.Any(str, {v.Optional("type"): str, v.Optional("uid"): str}),
+            v.Optional("datasource"): v.Any(
+                str, {v.Optional("type"): str, v.Optional("uid"): str}
+            ),
             v.Optional("hide"): v.All(int, v.Range(min=0, max=2)),
             v.Optional("regex"): v.All(str),
             v.Optional("label", default=""): v.All(str),

--- a/tests/schema/fixtures/dashboard-0038.json
+++ b/tests/schema/fixtures/dashboard-0038.json
@@ -1,0 +1,26 @@
+{
+    "dashboard": {
+        "new-dashboard": {
+            "title": "New dashboard",
+            "templating": {
+                "enabled": true,
+                "list": [
+                    {
+                        "name": "myqueue",
+                        "type": "query",
+                        "datasource": {
+                            "uid": "logistics-inhouse-prom"
+                        },
+                        "query": "label_values(metric{label=~\".*\"}, label)",
+                        "includeAll": true,
+                        "multi": true,
+                        "label": "",
+                        "refresh": 1
+                    }
+                ]
+            },
+            "timezone": "utc",
+            "panels": []
+        }
+    }
+}

--- a/tests/schema/fixtures/dashboard-0038.yaml
+++ b/tests/schema/fixtures/dashboard-0038.yaml
@@ -1,0 +1,10 @@
+dashboard:
+  title: New dashboard
+  templating:
+    - name: myqueue
+      type: query
+      datasource:
+        uid: logistics-inhouse-prom
+      query: label_values(metric{label=~".*"}, label)
+      includeAll: true
+      multi: true

--- a/tests/schema/fixtures/dashboard-0039.json
+++ b/tests/schema/fixtures/dashboard-0039.json
@@ -1,0 +1,36 @@
+{
+    "dashboard": {
+        "new-dashboard": {
+            "title": "New dashboard",
+            "templating": {
+                "enabled": true,
+                "list": [
+                    {
+                        "name": "hpa_component",
+                        "type": "custom",
+                        "query": "api,messaging",
+                        "includeAll": false,
+                        "multi": true,
+                        "current": {
+                            "text": "api + messaging",
+                            "value": [
+                                "api",
+                                "messaging"
+                            ]
+                        },
+                        "options": [],
+                        "label": ""
+                    },
+                    {
+                        "name": "app_filter",
+                        "type": "constant",
+                        "query": "myapp",
+                        "hide": 2
+                    }
+                ]
+            },
+            "timezone": "utc",
+            "panels": []
+        }
+    }
+}

--- a/tests/schema/fixtures/dashboard-0039.yaml
+++ b/tests/schema/fixtures/dashboard-0039.yaml
@@ -1,0 +1,17 @@
+dashboard:
+  title: New dashboard
+  templating:
+    - name: hpa_component
+      type: custom
+      query: "api,messaging"
+      includeAll: false
+      multi: true
+      current:
+        text: api + messaging
+        value:
+          - api
+          - messaging
+    - name: app_filter
+      type: constant
+      query: "myapp"
+      hide: 2

--- a/tests/schema/panels/test_bargauge.py
+++ b/tests/schema/panels/test_bargauge.py
@@ -1,0 +1,29 @@
+import voluptuous as v
+from testtools import TestCase
+
+from grafana_dashboards.schema.panel.bargauge import Bargauge
+
+
+class TestCaseBargauge(TestCase):
+    def setUp(self):
+        super(TestCaseBargauge, self).setUp()
+        self.schema = Bargauge().get_schema()
+        self.base = {
+            "type": "bargauge",
+            "title": "test bargauge",
+            "targets": [],
+            "options": {"orientation": "auto", "displayMode": "lcd"},
+        }
+
+    def test_defaults(self):
+        self.schema(self.base)
+
+    def test_datasource_string(self):
+        panel = dict(self.base)
+        panel["datasource"] = "logistics-inhouse-prom"
+        self.schema(panel)
+
+    def test_datasource_dict(self):
+        panel = dict(self.base)
+        panel["datasource"] = {"uid": "logistics-inhouse-prom", "type": "prometheus"}
+        self.schema(panel)

--- a/tests/schema/panels/test_gauge.py
+++ b/tests/schema/panels/test_gauge.py
@@ -1,0 +1,39 @@
+import voluptuous as v
+from testtools import TestCase
+
+from grafana_dashboards.schema.panel.gauge import Gauge
+
+
+class TestCaseGauge(TestCase):
+    def setUp(self):
+        super(TestCaseGauge, self).setUp()
+        self.schema = Gauge().get_schema()
+        self.base = {"type": "gauge", "title": "test gauge", "targets": []}
+
+    def test_defaults(self):
+        self.schema(self.base)
+
+    def test_min_max_int(self):
+        panel = dict(self.base)
+        panel["fieldConfig"] = {"defaults": {"min": 0, "max": 100}, "overrides": []}
+        self.schema(panel)
+
+    def test_min_max_float(self):
+        panel = dict(self.base)
+        panel["fieldConfig"] = {"defaults": {"min": 0.0, "max": 1.0}, "overrides": []}
+        self.schema(panel)
+
+    def test_datasource_string(self):
+        panel = dict(self.base)
+        panel["datasource"] = "logistics-inhouse-prom"
+        self.schema(panel)
+
+    def test_datasource_dict(self):
+        panel = dict(self.base)
+        panel["datasource"] = {"uid": "logistics-inhouse-prom", "type": "prometheus"}
+        self.schema(panel)
+
+    def test_min_invalid(self):
+        panel = dict(self.base)
+        panel["fieldConfig"] = {"defaults": {"min": "not-a-number"}, "overrides": []}
+        self.assertRaises(v.Invalid, self.schema, panel)

--- a/tests/schema/panels/test_logs.py
+++ b/tests/schema/panels/test_logs.py
@@ -1,0 +1,46 @@
+import voluptuous as v
+from testtools import TestCase
+
+from grafana_dashboards.schema.panel.logs import Logs
+
+
+class TestCaseLogs(TestCase):
+    def setUp(self):
+        super(TestCaseLogs, self).setUp()
+        self.schema = Logs().get_schema()
+        self.base = {"type": "logs", "title": "test logs", "targets": []}
+
+    def test_defaults(self):
+        self.schema(self.base)
+
+    def test_dedup_strategy_values(self):
+        for value in ("none", "exact", "numbers", "signature"):
+            panel = dict(self.base)
+            panel["options"] = {"dedupStrategy": value}
+            self.schema(panel)
+
+    def test_dedup_strategy_invalid(self):
+        panel = dict(self.base)
+        panel["options"] = {"dedupStrategy": "invalid"}
+        self.assertRaises(v.Invalid, self.schema, panel)
+
+    def test_sort_order_values(self):
+        for value in ("Ascending", "Descending"):
+            panel = dict(self.base)
+            panel["options"] = {"sortOrder": value}
+            self.schema(panel)
+
+    def test_sort_order_invalid(self):
+        panel = dict(self.base)
+        panel["options"] = {"sortOrder": "invalid"}
+        self.assertRaises(v.Invalid, self.schema, panel)
+
+    def test_datasource_string(self):
+        panel = dict(self.base)
+        panel["datasource"] = "logistics-inhouse-prom"
+        self.schema(panel)
+
+    def test_datasource_dict(self):
+        panel = dict(self.base)
+        panel["datasource"] = {"uid": "logistics-inhouse-prom", "type": "prometheus"}
+        self.schema(panel)


### PR DESCRIPTION
## Description

Mostly I'm changing datasource to accept dict (can be an object )
```
datasource: 
  uid: x
```
on more modern Grafana instances.

But I'm also keeping the old behavior (string) 

During that I found a couple of other small issues 


Summary of the changes: 

  - template/query.py — datasource accepts dict (modern Grafana uid-object format)
  - template/__init__.py — if/elif chain prevents schema leaking to constant type variables
  - panel/logs.py — dedupStrategy/sortOrder use v.Any() (was broken v.All() impossible enum); datasource accepts dict
  - panel/gauge.py — min/max use v.Number() with no default (was string default "0" failing int validator); datasource accepts dict
  - panel/bargauge.py — datasource accepts dict

## Why?

fixing sort order on Logs panel, fixing chain leaking on if chain and gauge default. 

## How?


## Checklist

- [X] I have performed a self-review of my own code
- [X] I have added or updated relevant tests
- [X] I have updated the documentation (if necessary)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify):
