### PR TITLE
feat: add folderUid support

### DIFF
--- a/grafana_dashboards/builder.py
+++ b/grafana_dashboards/builder.py
@@ -28,6 +28,7 @@ class Builder(object):
             config.get("cache", "cachedir"), config.getboolean("cache", "enabled")
         )
         self.folder_id = config.getint("grafana", "folderid")
+        self.folder_uid = config.get("grafana", "folderuid")
         self.grafana = Grafana(
             url=config.get("grafana", "url"), key=config.get("grafana", "apikey")
         )
@@ -98,7 +99,10 @@ class Builder(object):
             if self.cache.has_changed(name, md5):
                 permissions = self.parser.get_permissions(name)
                 uid = self.grafana.dashboard.create(
-                    data=data, overwrite=self.overwrite, folder_id=self.folder_id
+                    data=data,
+                    overwrite=self.overwrite,
+                    folder_id=self.folder_id,
+                    folder_uid=self.folder_uid,
                 )
                 if uid and permissions:
                     LOG.debug("Updating permissions for dashboard UID %s", uid)

--- a/grafana_dashboards/cmd.py
+++ b/grafana_dashboards/cmd.py
@@ -77,6 +77,11 @@ class Client(object):
             help="The id of the folder to save the dashboard in.",
         )
         parser.add_argument(
+            "--grafana-folderuid",
+            dest="grafana_folderuid",
+            help="The UID of the folder to save the dashboard in. Takes precedence over --grafana-folderid on Grafana 10+.",
+        )
+        parser.add_argument(
             "--version",
             dest="version",
             action="version",
@@ -133,6 +138,9 @@ class Client(object):
         if self.args.grafana_folderid:
             self.config.set("grafana", "folderid", self.args.grafana_folderid)
             LOG.debug("Grafana Folderid overridden")
+        if self.args.grafana_folderuid:
+            self.config.set("grafana", "folderuid", self.args.grafana_folderuid)
+            LOG.debug("Grafana Folderuid overridden")
 
         self.config.set("grafana", "overwrite", str(self.args.overwrite))
 

--- a/grafana_dashboards/config.py
+++ b/grafana_dashboards/config.py
@@ -27,4 +27,5 @@ class Config(ConfigParser.ConfigParser):
         self.set("grafana", "apikey", "")
         self.set("grafana", "url", "http://localhost:8080")
         self.set("grafana", "folderid", "0")
+        self.set("grafana", "folderuid", "")
         self.set("grafana", "overwrite", "true")

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -51,17 +51,11 @@ class Dashboard(object):
 
         if len(dashboards) > 1 and overwrite:
             yaml_uid = data.get("uid")
-            if yaml_uid:
-                exact = [d for d in dashboards if d.get("uid") == yaml_uid]
-                if len(exact) == 1:
-                    dashboards = exact
-                else:
-                    uids = [d.get("uid") for d in dashboards]
-                    folder_ref = folder_uid or folder_id
-                    raise ValueError(
-                        f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_ref}. "
-                        f"Cannot overwrite. UIDs: {uids}"
-                    )
+            exact = (
+                [d for d in dashboards if d.get("uid") == yaml_uid] if yaml_uid else []
+            )
+            if len(exact) == 1:
+                dashboards = exact
             else:
                 uids = [d.get("uid") for d in dashboards]
                 folder_ref = folder_uid or folder_id
@@ -157,20 +151,17 @@ class Dashboard(object):
         dashboards = self.search_dashboards(title)
 
         if folder_uid:
-            return list(
-                filter(
-                    lambda x: x.get("title") == title
-                    and x.get("folderUid") == folder_uid,
-                    dashboards,
-                )
-            )
+            return [
+                d
+                for d in dashboards
+                if d.get("title") == title and d.get("folderUid") == folder_uid
+            ]
 
         if folder_id == 0:
             return dashboards
 
-        return list(
-            filter(
-                lambda x: x.get("title") == title and x.get("folderId") == folder_id,
-                dashboards,
-            )
-        )
+        return [
+            d
+            for d in dashboards
+            if d.get("title") == title and d.get("folderId") == folder_id
+        ]

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -24,7 +24,13 @@ class Dashboard(object):
         self.search_url = utils.urljoin(base_url, "api/search?type=dash-db")
         self.session = session
 
-    def create(self, data: Dict, overwrite: bool = False, folder_id: int = 0) -> str:
+    def create(
+        self,
+        data: Dict,
+        overwrite: bool = False,
+        folder_id: int = 0,
+        folder_uid: str = "",
+    ) -> str:
         """Create a new dashboard
 
         :param data: Dashboard model
@@ -32,19 +38,22 @@ class Dashboard(object):
         :param overwrite: Overwrite existing dashboard with newer version or
                           with the same dashboard title
         :type overwrite: bool
-        :param folder_id: The id of the folder to save the dashboard in.
+        :param folder_id: The numeric id of the folder to save the dashboard in (deprecated in Grafana 10+).
         :type folder_id: int
+        :param folder_uid: The UID of the folder to save the dashboard in. Takes precedence on Grafana 10+.
+        :type folder_uid: str
 
         :raises Exception: if dashboard already exists
 
         """
         title = str(data.get("title"))
-        dashboards = self.find_dashboards_by_title(title, folder_id)
+        dashboards = self.find_dashboards_by_title(title, folder_id, folder_uid)
 
         if len(dashboards) > 1 and overwrite:
             uids = [d.get("uid") for d in dashboards]
+            folder_ref = folder_uid or folder_id
             error_msg = (
-                f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_id}. "
+                f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_ref}. "
                 f"Cannot overwrite. UIDs: {uids}"
             )
             raise ValueError(error_msg)
@@ -59,6 +68,8 @@ class Dashboard(object):
             "folderId": folder_id,
             "overwrite": overwrite,
         }
+        if folder_uid:
+            dashboard["folderUid"] = folder_uid
 
         res = self.session.post(self.db_url, data=json.dumps(dashboard))
         res.raise_for_status()
@@ -118,27 +129,36 @@ class Dashboard(object):
 
         return dashboards
 
-    def find_dashboards_by_title(self, title: str, folder_id: int = 0) -> List[Dict]:
+    def find_dashboards_by_title(
+        self, title: str, folder_id: int = 0, folder_uid: str = ""
+    ) -> List[Dict]:
         """Find all dashboards with a specific title and in a specific folder
 
         Args:
             title: The title of the dashboards to find
-            folder_id: Optional folder ID to limit the search to
+            folder_id: Optional numeric folder ID to limit the search to (deprecated in Grafana 10+)
+            folder_uid: Optional folder UID to limit the search to. Takes precedence over folder_id on Grafana 10+.
 
         Returns:
             List of dashboard objects that match the criteria
         """
         dashboards = self.search_dashboards(title)
 
-        # If folder_id is 0, return all dashboards
+        if folder_uid:
+            return list(
+                filter(
+                    lambda x: x.get("title") == title
+                    and x.get("folderUid") == folder_uid,
+                    dashboards,
+                )
+            )
+
         if folder_id == 0:
             return dashboards
 
-        dashboards = list(
+        return list(
             filter(
                 lambda x: x.get("title") == title and x.get("folderId") == folder_id,
                 dashboards,
             )
         )
-
-        return dashboards

--- a/grafana_dashboards/grafana/dashboard.py
+++ b/grafana_dashboards/grafana/dashboard.py
@@ -50,13 +50,25 @@ class Dashboard(object):
         dashboards = self.find_dashboards_by_title(title, folder_id, folder_uid)
 
         if len(dashboards) > 1 and overwrite:
-            uids = [d.get("uid") for d in dashboards]
-            folder_ref = folder_uid or folder_id
-            error_msg = (
-                f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_ref}. "
-                f"Cannot overwrite. UIDs: {uids}"
-            )
-            raise ValueError(error_msg)
+            yaml_uid = data.get("uid")
+            if yaml_uid:
+                exact = [d for d in dashboards if d.get("uid") == yaml_uid]
+                if len(exact) == 1:
+                    dashboards = exact
+                else:
+                    uids = [d.get("uid") for d in dashboards]
+                    folder_ref = folder_uid or folder_id
+                    raise ValueError(
+                        f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_ref}. "
+                        f"Cannot overwrite. UIDs: {uids}"
+                    )
+            else:
+                uids = [d.get("uid") for d in dashboards]
+                folder_ref = folder_uid or folder_id
+                raise ValueError(
+                    f"Found {len(dashboards)} dashboards with name '{title}' in folder {folder_ref}. "
+                    f"Cannot overwrite. UIDs: {uids}"
+                )
 
         # If there is already a dashboard with the same name in the same folder, use its UID
         if dashboards and overwrite:

--- a/grafana_dashboards/grafana/permissions.py
+++ b/grafana_dashboards/grafana/permissions.py
@@ -7,7 +7,6 @@ import json
 from dogpile.cache.region import make_region
 from typing import Dict, Optional, List, Dict, Any, Tuple
 
-
 LOG = logging.getLogger(__name__)
 
 cache = make_region(name="team_user_cache").configure(

--- a/grafana_dashboards/schema/template/base.py
+++ b/grafana_dashboards/schema/template/base.py
@@ -14,7 +14,6 @@
 
 import voluptuous as v
 
-
 AUTO_INTERVAL = "$__auto_interval"
 ALL_CUSTOM = "$__all"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,4 +26,5 @@ class TestCaseConfig(TestCase):
         self.assertEqual(self.config.get("cache", "cachedir"), "~/.cache/grafyaml")
         self.assertEqual(self.config.get("grafana", "apikey"), "")
         self.assertEqual(self.config.get("grafana", "folderid"), "0")
+        self.assertEqual(self.config.get("grafana", "folderuid"), "")
         self.assertEqual(self.config.get("grafana", "url"), "http://localhost:8080")

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -225,6 +225,34 @@ class TestCaseGrafana(TestCase):
         self.assertNotIn("folderUid", request_data)
 
     @requests_mock.Mocker()
+    def test_create_dashboard_deduplicates_by_yaml_uid(self, mock_requests):
+        mock_requests.get(
+            "http://localhost/api/search?type=dash-db",
+            status_code=200,
+            json=[
+                {"title": "My Dashboard", "uid": "real-uid", "folderUid": "folder-abc"},
+                {
+                    "title": "My Dashboard",
+                    "uid": "sreal-uid",
+                    "folderUid": "folder-abc",
+                },
+            ],
+        )
+        mock_requests.post(
+            "http://localhost/api/dashboards/db/",
+            status_code=200,
+            json={"uid": "real-uid"},
+        )
+
+        data = {"title": "My Dashboard", "uid": "real-uid", "rows": []}
+        uid = self.grafana.dashboard.create(
+            data=data, overwrite=True, folder_uid="folder-abc"
+        )
+        self.assertEqual(uid, "real-uid")
+        request_data = json.loads(mock_requests.last_request.body)
+        self.assertEqual(request_data["dashboard"]["uid"], "real-uid")
+
+    @requests_mock.Mocker()
     def test_find_dashboards_by_folder_uid(self, mock_requests):
         mock_requests.get(
             "http://localhost/api/search?type=dash-db",

--- a/tests/test_grafana.py
+++ b/tests/test_grafana.py
@@ -181,6 +181,94 @@ class TestCaseGrafana(TestCase):
         self.assertEqual(items[1]["permission"], 2)
 
     @requests_mock.Mocker()
+    def test_create_dashboard_with_folder_uid(self, mock_requests):
+        mock_requests.get(
+            "http://localhost/api/search?type=dash-db",
+            status_code=200,
+            json=[],
+        )
+        mock_requests.post(
+            "http://localhost/api/dashboards/db/",
+            status_code=200,
+            json={"uid": "new-uid"},
+        )
+
+        data = {"title": "Test Dashboard", "rows": [], "id": None, "version": 0}
+        self.grafana.dashboard.create(
+            data=data, folder_id=123, folder_uid="abc-folder-uid"
+        )
+
+        last_request = mock_requests.last_request
+        request_data = json.loads(last_request.body)
+        self.assertEqual(request_data["folderId"], 123)
+        self.assertEqual(request_data["folderUid"], "abc-folder-uid")
+
+    @requests_mock.Mocker()
+    def test_create_dashboard_folder_uid_omitted_when_not_set(self, mock_requests):
+        mock_requests.get(
+            "http://localhost/api/search?type=dash-db",
+            status_code=200,
+            json=[],
+        )
+        mock_requests.post(
+            "http://localhost/api/dashboards/db/",
+            status_code=200,
+            json={"uid": "new-uid"},
+        )
+
+        data = {"title": "Test Dashboard", "rows": [], "id": None, "version": 0}
+        self.grafana.dashboard.create(data=data, folder_id=123)
+
+        last_request = mock_requests.last_request
+        request_data = json.loads(last_request.body)
+        self.assertEqual(request_data["folderId"], 123)
+        self.assertNotIn("folderUid", request_data)
+
+    @requests_mock.Mocker()
+    def test_find_dashboards_by_folder_uid(self, mock_requests):
+        mock_requests.get(
+            "http://localhost/api/search?type=dash-db",
+            status_code=200,
+            json=[
+                {
+                    "title": "My Dashboard",
+                    "uid": "uid-1",
+                    "folderUid": "folder-abc",
+                    "folderId": 42,
+                },
+                {
+                    "title": "My Dashboard",
+                    "uid": "uid-2",
+                    "folderUid": "folder-xyz",
+                    "folderId": 99,
+                },
+            ],
+        )
+
+        result = self.grafana.dashboard.find_dashboards_by_title(
+            "My Dashboard", folder_uid="folder-abc"
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["uid"], "uid-1")
+
+    @requests_mock.Mocker()
+    def test_find_dashboards_by_folder_id_backward_compat(self, mock_requests):
+        mock_requests.get(
+            "http://localhost/api/search?type=dash-db",
+            status_code=200,
+            json=[
+                {"title": "My Dashboard", "uid": "uid-1", "folderId": 42},
+                {"title": "My Dashboard", "uid": "uid-2", "folderId": 99},
+            ],
+        )
+
+        result = self.grafana.dashboard.find_dashboards_by_title(
+            "My Dashboard", folder_id=42
+        )
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["uid"], "uid-1")
+
+    @requests_mock.Mocker()
     def test_delete_dashboard(self, mock_requests):
         mock_requests.delete("/api/dashboards/db/new-dashboard", status_code=200)
         self.grafana.dashboard.delete("new-dashboard")


### PR DESCRIPTION
## Description

Adding the new usage of folderUid instead of folderId (deprecated in newer grafana versions). 

Added it with backward compatible, so it remains working if folderId is set, folderUid takes precedence if set.

## Why?

When using the newer grafana versions folderId was silently skipped and dashboards were landing in the default root folder. 

## How?

_A brief explanation of how the changes were implemented._

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have added or updated relevant tests
- [X] I have updated the documentation (if necessary)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify):
