### PR TITLE
fix: pin setuptools_scm<8 in pyproject.toml to fix install on Python 3.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "setuptools_scm<8"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Description

pin setuptools_scm<8 in pyproject.toml to fix install on Python 3.8

## Why?

_The reason for this change._

## How?

_A brief explanation of how the changes were implemented._

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added or updated relevant tests
- [ ] I have updated the documentation (if necessary)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Other (please specify):
